### PR TITLE
Add optional managed app unfreeze on VPN toggle

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/BootReceiver.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/BootReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.settings.AppSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -15,8 +16,9 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         if (intent?.action != Intent.ACTION_BOOT_COMPLETED) return
 
-        val prefs = context.getSharedPreferences("settings", Context.MODE_PRIVATE)
-        if (!prefs.getBoolean("freeze_on_boot", false)) return
+        // Reuse the shared settings accessor so boot flow reads the same keys as UI.
+        val prefs = AppSettings.prefs(context)
+        if (!prefs.getBoolean(AppSettings.KEY_FREEZE_ON_BOOT, false)) return
 
         val app = context.applicationContext as AnubisApp
         val shizukuManager = app.shizukuManager

--- a/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientType
@@ -33,8 +34,10 @@ class ShortcutActivity : ComponentActivity() {
         val repository = AppRepository(app.database.managedAppDao(), this)
         val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repository)
 
-        val prefs = getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val pkg = prefs.getString("vpn_client_package", null) ?: VpnClientType.V2RAY_NG.packageName
+        // Shortcut launches must use the same selected VPN client as the main app UI.
+        val prefs = AppSettings.prefs(this)
+        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
+            ?: VpnClientType.V2RAY_NG.packageName
         val client = SelectedVpnClient.fromPackage(pkg)
 
         // Ensure UserService is bound (instant if already connected)

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -3,6 +3,7 @@ package sgnv.anubis.app.service
 import android.content.Context
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.shizuku.ShizukuManager
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientManager
@@ -99,9 +100,8 @@ class StealthOrchestrator(
             }
         }
 
-        freezeGroup(AppGroup.VPN_ONLY)
-        bumpVersion()
-        _state.value = StealthState.DISABLED
+        // After confirmed VPN shutdown, align managed groups with the new network state.
+        applyManagedStateForVpn(active = false)
     }
 
     /**
@@ -110,9 +110,8 @@ class StealthOrchestrator(
     suspend fun freezeOnly() {
         _lastError.value = null
         if (!checkShizuku()) return
-        freezeGroup(AppGroup.LOCAL)
-        bumpVersion()
-        _state.value = StealthState.ENABLED
+        // Handle external/manual VPN activation using the same managed-group rules.
+        applyManagedStateForVpn(active = true)
     }
 
     /**
@@ -120,9 +119,8 @@ class StealthOrchestrator(
      */
     suspend fun freezeVpnOnly() {
         if (!checkShizuku()) return
-        freezeGroup(AppGroup.VPN_ONLY)
-        bumpVersion()
-        _state.value = StealthState.DISABLED
+        // Handle external/manual VPN shutdown using the same managed-group rules.
+        applyManagedStateForVpn(active = false)
     }
 
     /**
@@ -221,6 +219,38 @@ class StealthOrchestrator(
                 shizukuManager.freezeApp(pkg)
             }
         }
+    }
+
+    private suspend fun unfreezeGroup(group: AppGroup) {
+        val packages = repository.getPackagesByGroup(group)
+        for (pkg in packages) {
+            if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
+                shizukuManager.unfreezeApp(pkg)
+            }
+        }
+    }
+
+    private suspend fun applyManagedStateForVpn(active: Boolean) {
+        if (active) {
+            freezeGroup(AppGroup.LOCAL)
+            // Optional issue #31 behavior: make VPN_ONLY apps usable immediately after VPN comes up.
+            if (shouldUnfreezeManagedAppsOnVpnToggle()) {
+                unfreezeGroup(AppGroup.VPN_ONLY)
+            }
+            _state.value = StealthState.ENABLED
+        } else {
+            freezeGroup(AppGroup.VPN_ONLY)
+            // Optional issue #31 behavior: restore LOCAL apps once VPN is fully down.
+            if (shouldUnfreezeManagedAppsOnVpnToggle()) {
+                unfreezeGroup(AppGroup.LOCAL)
+            }
+            _state.value = StealthState.DISABLED
+        }
+        bumpVersion()
+    }
+
+    private fun shouldUnfreezeManagedAppsOnVpnToggle(): Boolean {
+        return AppSettings.shouldUnfreezeManagedAppsOnVpnToggle(context)
     }
 
     private suspend fun waitForVpnOff(timeoutMs: Long): Boolean {

--- a/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
@@ -7,6 +7,7 @@ import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientType
@@ -34,8 +35,10 @@ class StealthTileService : TileService() {
         val repo = AppRepository(app.database.managedAppDao(), this)
         val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repo)
 
-        val prefs = getSharedPreferences("settings", MODE_PRIVATE)
-        val pkg = prefs.getString("vpn_client_package", null) ?: VpnClientType.V2RAY_NG.packageName
+        // Tile uses the same selected client preference as the rest of the app.
+        val prefs = AppSettings.prefs(this)
+        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
+            ?: VpnClientType.V2RAY_NG.packageName
         val client = SelectedVpnClient.fromPackage(pkg)
 
         // Ensure UserService is bound (instant if Shizuku is ready)

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -20,6 +20,7 @@ import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.ui.MainActivity
 
 /**
@@ -65,7 +66,7 @@ class VpnMonitorService : Service() {
         networkCallback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 // VPN turned ON — freeze LOCAL group
-                scope.launch { freezeGroup(AppGroup.LOCAL) }
+                scope.launch { applyManagedStateForVpn(active = true) }
             }
 
             override fun onLost(network: Network) {
@@ -75,7 +76,7 @@ class VpnMonitorService : Service() {
                         ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
                 }
                 if (!stillActive) {
-                    scope.launch { freezeGroup(AppGroup.VPN_ONLY) }
+                    scope.launch { applyManagedStateForVpn(active = false) }
                 }
             }
         }
@@ -107,6 +108,38 @@ class VpnMonitorService : Service() {
         for (pkg in packages) {
             if (shizukuManager.isAppInstalled(pkg) && !shizukuManager.isAppFrozen(pkg)) {
                 shizukuManager.freezeApp(pkg)
+            }
+        }
+    }
+
+    private suspend fun unfreezeGroup(group: AppGroup) {
+        val app = applicationContext as AnubisApp
+        val shizukuManager = app.shizukuManager
+        if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
+        shizukuManager.bindUserService()
+        kotlinx.coroutines.delay(200)
+
+        val repo = AppRepository(app.database.managedAppDao(), applicationContext)
+        val packages = repo.getPackagesByGroup(group)
+        for (pkg in packages) {
+            if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
+                shizukuManager.unfreezeApp(pkg)
+            }
+        }
+    }
+
+    private suspend fun applyManagedStateForVpn(active: Boolean) {
+        if (active) {
+            freezeGroup(AppGroup.LOCAL)
+            // Mirror manual orchestration when VPN is toggled outside Anubis.
+            if (AppSettings.shouldUnfreezeManagedAppsOnVpnToggle(applicationContext)) {
+                unfreezeGroup(AppGroup.VPN_ONLY)
+            }
+        } else {
+            freezeGroup(AppGroup.VPN_ONLY)
+            // Mirror manual orchestration when VPN is toggled outside Anubis.
+            if (AppSettings.shouldUnfreezeManagedAppsOnVpnToggle(applicationContext)) {
+                unfreezeGroup(AppGroup.LOCAL)
             }
         }
     }

--- a/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
+++ b/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
@@ -1,0 +1,22 @@
+package sgnv.anubis.app.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/** Centralized SharedPreferences keys for app-level settings. */
+object AppSettings {
+    const val PREFS_NAME = "settings"
+    const val KEY_VPN_CLIENT_PACKAGE = "vpn_client_package"
+    const val KEY_BACKGROUND_MONITORING = "background_monitoring"
+    const val KEY_FREEZE_ON_BOOT = "freeze_on_boot"
+    const val KEY_UNFREEZE_ON_VPN_TOGGLE = "unfreeze_on_vpn_toggle"
+
+    fun prefs(context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    /** Optional behavior: unfreeze the opposite managed group after VPN state changes. */
+    fun shouldUnfreezeManagedAppsOnVpnToggle(context: Context): Boolean {
+        return prefs(context).getBoolean(KEY_UNFREEZE_ON_VPN_TOGGLE, false)
+    }
+}

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -1,7 +1,6 @@
 package sgnv.anubis.app.ui
 
 import android.app.Application
-import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -15,6 +14,7 @@ import sgnv.anubis.app.service.StealthOrchestrator
 import sgnv.anubis.app.service.StealthState
 import sgnv.anubis.app.service.StealthVpnService
 import sgnv.anubis.app.service.VpnMonitorService
+import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.update.UpdateChecker
 import sgnv.anubis.app.update.UpdateInfo
@@ -85,6 +85,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _backgroundMonitoring = MutableStateFlow(false)
     val backgroundMonitoring: StateFlow<Boolean> = _backgroundMonitoring
 
+    // Exposes issue #31 behavior to Compose settings UI.
+    private val _unfreezeManagedAppsOnVpnToggle = MutableStateFlow(false)
+    val unfreezeManagedAppsOnVpnToggle: StateFlow<Boolean> = _unfreezeManagedAppsOnVpnToggle
+
     private val _dangerousAppWarning = MutableStateFlow<String?>(null)
     val dangerousAppWarning: StateFlow<String?> = _dangerousAppWarning
 
@@ -109,6 +113,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         scheduleAutoFreeze()
         observeVpnState()
         loadBackgroundMonitoring()
+        loadUnfreezeManagedAppsOnVpnToggle()
         checkDangerousApps()
         loadUpdateCheckPref()
         autoCheckForUpdates()
@@ -326,10 +331,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun selectVpnClient(client: SelectedVpnClient) {
         _selectedVpnClient.value = client
-        getApplication<Application>()
-            .getSharedPreferences("settings", Context.MODE_PRIVATE)
+        AppSettings.prefs(getApplication())
             .edit()
-            .putString("vpn_client_package", client.packageName)
+            .putString(AppSettings.KEY_VPN_CLIENT_PACKAGE, client.packageName)
             .apply()
     }
 
@@ -342,8 +346,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun setBackgroundMonitoring(enabled: Boolean) {
         _backgroundMonitoring.value = enabled
         val app = getApplication<Application>()
-        app.getSharedPreferences("settings", Context.MODE_PRIVATE)
-            .edit().putBoolean("background_monitoring", enabled).apply()
+        AppSettings.prefs(app)
+            .edit()
+            .putBoolean(AppSettings.KEY_BACKGROUND_MONITORING, enabled)
+            .apply()
         if (enabled) {
             VpnMonitorService.start(app)
         } else {
@@ -352,13 +358,27 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun loadBackgroundMonitoring() {
-        val prefs = getApplication<Application>()
-            .getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val enabled = prefs.getBoolean("background_monitoring", false)
+        val enabled = AppSettings.prefs(getApplication())
+            .getBoolean(AppSettings.KEY_BACKGROUND_MONITORING, false)
         _backgroundMonitoring.value = enabled
         if (enabled) {
             VpnMonitorService.start(getApplication())
         }
+    }
+
+    fun setUnfreezeManagedAppsOnVpnToggle(enabled: Boolean) {
+        _unfreezeManagedAppsOnVpnToggle.value = enabled
+        // Persist immediately so orchestrators and services pick the flag up without restart.
+        AppSettings.prefs(getApplication())
+            .edit()
+            .putBoolean(AppSettings.KEY_UNFREEZE_ON_VPN_TOGGLE, enabled)
+            .apply()
+    }
+
+    private fun loadUnfreezeManagedAppsOnVpnToggle() {
+        // Load once on startup; services read the same flag directly from shared prefs.
+        _unfreezeManagedAppsOnVpnToggle.value = AppSettings.prefs(getApplication())
+            .getBoolean(AppSettings.KEY_UNFREEZE_ON_VPN_TOGGLE, false)
     }
 
     fun dismissDangerousAppWarning() {
@@ -469,9 +489,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun loadSelectedClient() {
-        val prefs = getApplication<Application>()
-            .getSharedPreferences("settings", Context.MODE_PRIVATE)
-        val pkg = prefs.getString("vpn_client_package", null)
+        val prefs = AppSettings.prefs(getApplication())
+        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
             ?: prefs.getString("vpn_client", null)?.let {
                 // Migration from old format (enum name → package name)
                 try { VpnClientType.valueOf(it).packageName } catch (e: Exception) { null }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -59,6 +59,7 @@ fun SettingsScreen(
     val selectedClient by viewModel.selectedVpnClient.collectAsState()
     val installedClients by viewModel.installedVpnClients.collectAsState()
     val shizukuStatus by viewModel.shizukuStatus.collectAsState()
+    val unfreezeManagedAppsOnVpnToggle by viewModel.unfreezeManagedAppsOnVpnToggle.collectAsState()
     var showAppPicker by remember { mutableStateOf(false) }
 
     Column(
@@ -185,6 +186,30 @@ fun SettingsScreen(
                 androidx.compose.material3.Switch(
                     checked = bgMonitoring,
                     onCheckedChange = { viewModel.setBackgroundMonitoring(it) }
+                )
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        // Optional issue #31 setting: switch between strict freeze-only mode and auto-unfreeze mode.
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Размораживать группы при включении/отключении VPN", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        "После включения VPN размораживает \"Только VPN\", после отключения — \"Без VPN\"",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                androidx.compose.material3.Switch(
+                    checked = unfreezeManagedAppsOnVpnToggle,
+                    onCheckedChange = { viewModel.setUnfreezeManagedAppsOnVpnToggle(it) }
                 )
             }
         }


### PR DESCRIPTION
## Что сделано

Реализован `#31`: добавлена опциональная настройка, которая автоматически размораживает управляемые группы приложений при изменении состояния VPN.

Если настройка включена:

- при включении VPN замораживается группа `LOCAL` и размораживается группа `VPN_ONLY`
- при отключении VPN замораживается группа `VPN_ONLY` и размораживается группа `LOCAL`

Если настройка выключена, сохраняется прежнее поведение: Anubis только замораживает нужные группы автоматически, а разморозка происходит только при явном запуске приложения.

## Изменения в коде

- добавлен новый флаг настроек `unfreeze_on_vpn_toggle`
- вынесены ключи `SharedPreferences` в общий объект `AppSettings`
- в экран настроек добавлен новый свитч: `Размораживать группы при включении/отключении VPN`
- обновлен `StealthOrchestrator`, чтобы ручные сценарии включения и отключения VPN учитывали новую опцию
- обновлен `VpnMonitorService`, чтобы внешние изменения состояния VPN вне Anubis использовали ту же логику заморозки и разморозки групп
- `BootReceiver`, `ShortcutActivity` и `StealthTileService` переведены на чтение настроек через общий accessor
- в измененные места добавлены комментарии по новой логике issue `#31`

## Как протестировано

### Сборка и окружение

- установлены необходимые пакеты Android SDK:
  - `platforms;android-34`
  - `platforms;android-29`
  - `platform-tools`
  - `build-tools;34.0.0`
- во время сборки Gradle дополнительно подтянул `build-tools;35.0.0`
- проект успешно собирается командой:

```powershell
.\gradlew.bat assembleDebug
```

### Проверка логики

- проверено, что новая настройка отображается в `Settings`
- проверено, что новая логика подключена в оба сценария:
  - ручная оркестрация внутри Anubis через `StealthOrchestrator`
  - фоновый мониторинг изменений VPN через `VpnMonitorService`
- проверено, что старое поведение сохраняется, когда настройка выключена, так как разморозка защищена новым preference-флагом

## Что нужно дальше от разработчиков

- вручную проверить на устройстве оба состояния нового свитча:
  - VPN: `OFF -> ON`
  - VPN: `ON -> OFF`
  - отдельно через Anubis и отдельно через внешний VPN-клиент
- подтвердить ожидаемый UX для приложений, которые были разморожены вручную до смены состояния VPN
- решить, должен ли новый флаг по умолчанию оставаться `false` или в будущем его стоит включить по умолчанию
- отдельно рассмотреть cleanup старых warning-ов по deprecated API (`allNetworks`, `Icons.Filled.List`)

## Примечания

- коммит с изменениями: `919d958`
