### PR TITLE
[codex] Add Tunguska VPN client integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
     // Room
     implementation("androidx.room:room-runtime:2.6.1")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,3 +13,9 @@
 
 # Room TypeConverters
 -keep class sgnv.anubis.app.data.db.AppGroupConverter { *; }
+
+# Tink (pulled in by androidx.security:security-crypto for EncryptedSharedPreferences).
+# These annotation packages are compile-only — absent at runtime. R8 otherwise fails.
+-dontwarn com.google.errorprone.annotations.**
+-dontwarn javax.annotation.**
+-dontwarn javax.annotation.concurrent.**

--- a/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
+++ b/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.sync.Mutex
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import sgnv.anubis.app.data.db.AppDatabase
@@ -40,6 +43,15 @@ class AnubisApp : Application() {
      * target state, and returns without doing any work.
      */
     val groupOpMutex: Mutex = Mutex()
+
+    /**
+     * Process-wide scope for orchestrator work that must outlive any single suspension
+     * point. Used so enable()/disable() can launch the freeze/VPN sequence in a detached
+     * Job and wait via job.join() with a hard timeout — if the underlying binder hangs,
+     * the user-facing state recovers even though the orphan continues running until
+     * the binder eventually returns.
+     */
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
+++ b/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
@@ -7,13 +7,30 @@ import android.os.Build
 import kotlinx.coroutines.sync.Mutex
 import org.lsposed.hiddenapibypass.HiddenApiBypass
 import sgnv.anubis.app.data.db.AppDatabase
+import sgnv.anubis.app.data.repository.AppRepository
+import sgnv.anubis.app.service.StealthOrchestrator
 import sgnv.anubis.app.shizuku.ShizukuManager
+import sgnv.anubis.app.vpn.VpnClientManager
 
 class AnubisApp : Application() {
 
     val database: AppDatabase by lazy { AppDatabase.getInstance(this) }
     lateinit var shizukuManager: ShizukuManager
         private set
+
+    // Process-wide singletons so MainViewModel and VpnMonitorService share the same
+    // state (_vpnActive, StealthState). Previously each had its own VpnClientManager/
+    // orchestrator, so the service could freeze groups on VPN drop but couldn't sync
+    // the orchestrator's _state — UI stayed "защита активна" while VPN was actually down.
+    val vpnClientManager: VpnClientManager by lazy {
+        VpnClientManager(this, shizukuManager)
+    }
+    val appRepository: AppRepository by lazy {
+        AppRepository(database.managedAppDao(), this)
+    }
+    val orchestrator: StealthOrchestrator by lazy {
+        StealthOrchestrator(this, shizukuManager, vpnClientManager, appRepository)
+    }
 
     /**
      * App-wide mutex for mass freeze/unfreeze operations. Prevents duplicate work when
@@ -38,6 +55,10 @@ class AnubisApp : Application() {
         // Init Shizuku once — all components share this instance
         shizukuManager = ShizukuManager(packageManager)
         shizukuManager.startListening()
+
+        // Start VPN monitoring at process level — VpnClientManager's NetworkCallback
+        // and _vpnActive StateFlow are shared by UI and VpnMonitorService.
+        vpnClientManager.startMonitoringVpn()
     }
 
     override fun onTerminate() {

--- a/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
@@ -7,8 +7,6 @@ import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.vpn.VpnClientManager
-import sgnv.anubis.app.vpn.SelectedVpnClient
-import sgnv.anubis.app.vpn.VpnClientType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -43,10 +41,7 @@ class ShortcutActivity : ComponentActivity() {
         val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repository)
 
         // Shortcut launches must use the same selected VPN client as the main app UI.
-        val prefs = AppSettings.prefs(this)
-        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
-            ?: VpnClientType.V2RAY_NG.packageName
-        val client = SelectedVpnClient.fromPackage(pkg)
+        val client = AppSettings.loadSelectedVpnClient(this)
 
         // Ensure UserService is bound (instant if already connected)
         vpnClientManager.startMonitoringVpn()
@@ -72,8 +67,11 @@ class ShortcutActivity : ComponentActivity() {
                     vpnClientManager.detectActiveVpnClient()
                     val detectedPkg = vpnClientManager.activeVpnPackage.value
                     val detected = vpnClientManager.activeVpnClient.value
-                    val stopClient = if (detected != null) SelectedVpnClient.fromKnown(detected)
-                        else detectedPkg?.let { SelectedVpnClient.fromPackage(it) } ?: client
+                    val stopClient = if (detected != null) {
+                        AppSettings.loadSelectedVpnClient(this@ShortcutActivity, detected.packageName)
+                    } else detectedPkg?.let {
+                        AppSettings.loadSelectedVpnClient(this@ShortcutActivity, it)
+                    } ?: client
                     orchestrator.launchLocal(packageName, stopClient, detectedPkg)
                 }
                 AppGroup.VPN_ONLY, AppGroup.LAUNCH_VPN -> {

--- a/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
@@ -4,9 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.model.AppGroup
-import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
-import sgnv.anubis.app.vpn.VpnClientManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,15 +34,12 @@ class ShortcutActivity : ComponentActivity() {
 
         val app = applicationContext as AnubisApp
         val shizukuManager = app.shizukuManager
-        val vpnClientManager = VpnClientManager(this, shizukuManager)
-        val repository = AppRepository(app.database.managedAppDao(), this)
-        val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repository)
+        val vpnClientManager = app.vpnClientManager
+        val repository = app.appRepository
+        val orchestrator = app.orchestrator
 
         // Shortcut launches must use the same selected VPN client as the main app UI.
         val client = AppSettings.loadSelectedVpnClient(this)
-
-        // Ensure UserService is bound (instant if already connected)
-        vpnClientManager.startMonitoringVpn()
 
         CoroutineScope(Dispatchers.Main).launch {
             shizukuManager.awaitUserService()
@@ -79,7 +74,6 @@ class ShortcutActivity : ComponentActivity() {
                 }
             }
 
-            vpnClientManager.stopMonitoringVpn()
             finish()
         }
     }

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -9,6 +9,7 @@ import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.VpnControlMode
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -17,9 +18,12 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicInteger
 import sgnv.anubis.app.AnubisApp
 
@@ -79,10 +83,39 @@ class StealthOrchestrator(
      * Enable stealth (VPN ON): freeze LOCAL apps, start VPN.
      * VPN_ONLY stays frozen — they are only unfrozen by explicit launch.
      */
-    suspend fun enable(client: SelectedVpnClient) {
+    suspend fun enable(client: SelectedVpnClient) = withContext(Dispatchers.Default) {
+        // Detached-job pattern: enableImpl runs in a process-wide scope, we wait via
+        // job.join() with a hard timeout. Why: the original `withTimeoutOrNull(120s) {
+        // enableImpl(...) }` couldn't fire because enableImpl's chain hits a
+        // `withContext(Dispatchers.IO) { sync_binder_call }` (Shizuku userService.execCommand
+        // for am broadcast / dumpsys), and Kotlin cancellation is cooperative — withContext
+        // can't return until the IO block completes. join() IS truly cancellable, so the
+        // user-facing state recovers at 120 s even if the binder is wedged. The orphan
+        // continues until the binder eventually returns; at most one orphan, and the
+        // groupOpMutex is released long before the hang point (after freezeGroup).
         _lastError.value = null
         _state.value = StealthState.ENABLING
+        val app = context.applicationContext as AnubisApp
+        val job = app.scope.launch { enableImpl(client) }
+        try {
+            val finished = withTimeoutOrNull(TOTAL_OP_TIMEOUT_MS) {
+                job.join(); true
+            } ?: false
+            if (!finished) {
+                job.cancel()  // best-effort; sync binder won't actually interrupt
+                _progressText.value = null
+                _lastError.value = "Операция превысила таймаут (${TOTAL_OP_TIMEOUT_MS / 1000} с). Попробуйте снова."
+                _state.value = StealthState.DISABLED
+            }
+        } finally {
+            // Safety: never leave _state stuck in a transitional value — align with
+            // actual VPN state so UI can't get stuck on the orange "ENABLING" banner
+            // regardless of cancellation, missed code path or unexpected exception.
+            alignStateWithVpn()
+        }
+    }
 
+    private suspend fun enableImpl(client: SelectedVpnClient) {
         if (!checkShizuku()) return
 
         if (shouldFreezeClientInIdle(client.packageName)) {
@@ -135,10 +168,27 @@ class StealthOrchestrator(
      * Disable stealth (VPN OFF): stop VPN, freeze VPN_ONLY apps.
      * LOCAL stays frozen — they are only unfrozen by explicit launch.
      */
-    suspend fun disable(client: SelectedVpnClient, detectedPackage: String?) {
+    suspend fun disable(client: SelectedVpnClient, detectedPackage: String?) = withContext(Dispatchers.Default) {
+        // See comment on enable() — same detached-job + join() with timeout pattern.
         _lastError.value = null
         _state.value = StealthState.DISABLING
+        val app = context.applicationContext as AnubisApp
+        val job = app.scope.launch { disableImpl(client, detectedPackage) }
+        try {
+            val finished = withTimeoutOrNull(TOTAL_OP_TIMEOUT_MS) {
+                job.join(); true
+            } ?: false
+            if (!finished) {
+                job.cancel()
+                _progressText.value = null
+                _lastError.value = "Операция превысила таймаут (${TOTAL_OP_TIMEOUT_MS / 1000} с). Попробуйте снова."
+            }
+        } finally {
+            alignStateWithVpn()
+        }
+    }
 
+    private suspend fun disableImpl(client: SelectedVpnClient, detectedPackage: String?) {
         if (vpnClientManager.vpnActive.value) {
             _progressText.value = "Отключаю VPN..."
             if (!stopVpn(client, detectedPackage)) {
@@ -153,6 +203,17 @@ class StealthOrchestrator(
         // After confirmed VPN shutdown, align managed groups with the new network state.
         applyManagedStateForVpn(active = false)
         _progressText.value = null
+    }
+
+    private fun alignStateWithVpn() {
+        val current = _state.value
+        if (current == StealthState.ENABLING || current == StealthState.DISABLING) {
+            _state.value = if (vpnClientManager.vpnActive.value) {
+                StealthState.ENABLED
+            } else {
+                StealthState.DISABLED
+            }
+        }
     }
 
     /**
@@ -395,6 +456,15 @@ class StealthOrchestrator(
         // v0.1.5 binder path removes the shell-timeout class of failures but
         // not the broadcast-storm class, so parallelism stays low.
         const val FREEZE_CONCURRENCY = 2
+
+        // Hard ceiling for the entire enable/disable operation. Realistic budget:
+        // freezeGroup ~5 s (binder calls finish in <200 ms each, semaphore=2),
+        // startVPN 1–3 s, waitForVpnOn up to 10 s ≈ 20 s typical.
+        // 45 s covers slow OEMs + a couple of stuck binder calls hitting their 5 s
+        // BINDER_OP_TIMEOUT_MS cap, while still bailing before the user reaches for
+        // force-stop. If we hit this ceiling something is genuinely broken (Shizuku
+        // wedged, VPN client unresponsive) — no point waiting longer.
+        const val TOTAL_OP_TIMEOUT_MS = 45_000L
     }
 }
 

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -6,6 +6,7 @@ import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.shizuku.ShizukuManager
 import sgnv.anubis.app.vpn.SelectedVpnClient
+import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.VpnControlMode
 import kotlinx.coroutines.async
@@ -86,7 +87,6 @@ class StealthOrchestrator(
 
         if (shouldFreezeClientInIdle(client.packageName)) {
             shizukuManager.unfreezeApp(client.packageName)
-            delay(200)
         }
 
         if (shizukuManager.isAppFrozen(client.packageName)) {
@@ -103,7 +103,11 @@ class StealthOrchestrator(
         emitBenchmark(frozen = frozen, unfrozen = 0, startMs = benchStart)
 
         _progressText.value = "Запускаю VPN..."
-        vpnClientManager.startVPN(client)
+        val startError = vpnClientManager.startVPN(client)
+        if (startError != null) {
+            fail(startError)
+            return
+        }
 
         if (client.controlMode != VpnControlMode.MANUAL && !waitForVpnOn(10_000)) {
             fail("VPN client ${client.displayName} did not come up in time.")
@@ -246,7 +250,7 @@ class StealthOrchestrator(
         return waitForVpnOff(2000)
     }
 
-    private fun checkShizuku(): Boolean {
+    private suspend fun checkShizuku(): Boolean {
         if (!shizukuManager.isAvailable()) { fail("Shizuku не запущен."); return false }
         if (!shizukuManager.hasPermission()) { fail("Нет разрешения Shizuku."); return false }
         return true
@@ -359,27 +363,24 @@ class StealthOrchestrator(
         return false
     }
 
-    private fun fail(message: String) {
+    private suspend fun fail(message: String) {
         _progressText.value = null
+        freezeSelectedVpnClientIfNeeded()
         _lastError.value = message
         _state.value = StealthState.DISABLED
     }
 
     private suspend fun freezeSelectedVpnClientIfNeeded() {
-        val packageName = AppSettings.prefs(context)
-            .getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
-            .orEmpty()
-        if (!shouldFreezeClientInIdle(packageName)) return
-        shizukuManager.bindUserService()
-        delay(200)
-        shizukuManager.freezeApp(packageName)
+        val client = AppSettings.loadSelectedVpnClient(context)
+        if (!shouldFreezeClientInIdle(client.packageName)) return
+        if (!shizukuManager.awaitUserService(500)) return
+        shizukuManager.freezeApp(client.packageName)
     }
 
     private fun shouldFreezeClientInIdle(packageName: String): Boolean =
-        packageName == TUNGUSKA_PACKAGE
+        packageName.isNotBlank() && VpnClientControls.getControlForPackage(packageName).freezeInIdle
 
     private companion object {
-        const val TUNGUSKA_PACKAGE = "io.acionyx.tunguska"
         // Cap on concurrent Shizuku IPC calls during group freeze/unfreeze.
         // On Honor MagicOS parallel disable-user emits a flood of PACKAGE_REMOVED
         // broadcasts that overwhelms the stock launcher's grid repaint — 4 was

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -84,8 +84,13 @@ class StealthOrchestrator(
 
         if (!checkShizuku()) return
 
+        if (shouldFreezeClientInIdle(client.packageName)) {
+            shizukuManager.unfreezeApp(client.packageName)
+            delay(200)
+        }
+
         if (shizukuManager.isAppFrozen(client.packageName)) {
-            fail("VPN-клиент ${client.displayName} заморожен!")
+            fail("VPN client ${client.displayName} is still frozen.")
             return
         }
 
@@ -99,6 +104,11 @@ class StealthOrchestrator(
 
         _progressText.value = "Запускаю VPN..."
         vpnClientManager.startVPN(client)
+
+        if (client.controlMode != VpnControlMode.MANUAL && !waitForVpnOn(10_000)) {
+            fail("VPN client ${client.displayName} did not come up in time.")
+            return
+        }
 
         bumpVersion()
         _progressText.value = null
@@ -317,6 +327,7 @@ class StealthOrchestrator(
                 if (shouldUnfreezeManagedAppsOnVpnToggle()) {
                     unfrozen += unfreezeGroup(AppGroup.LOCAL)
                 }
+                freezeSelectedVpnClientIfNeeded()
                 _state.value = StealthState.DISABLED
             }
         }
@@ -338,13 +349,37 @@ class StealthOrchestrator(
         return false
     }
 
+    private suspend fun waitForVpnOn(timeoutMs: Long): Boolean {
+        val steps = (timeoutMs / 200).toInt()
+        repeat(steps) {
+            delay(200)
+            vpnClientManager.refreshVpnState()
+            if (vpnClientManager.vpnActive.value) return true
+        }
+        return false
+    }
+
     private fun fail(message: String) {
         _progressText.value = null
         _lastError.value = message
         _state.value = StealthState.DISABLED
     }
 
+    private suspend fun freezeSelectedVpnClientIfNeeded() {
+        val packageName = AppSettings.prefs(context)
+            .getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
+            .orEmpty()
+        if (!shouldFreezeClientInIdle(packageName)) return
+        shizukuManager.bindUserService()
+        delay(200)
+        shizukuManager.freezeApp(packageName)
+    }
+
+    private fun shouldFreezeClientInIdle(packageName: String): Boolean =
+        packageName == TUNGUSKA_PACKAGE
+
     private companion object {
+        const val TUNGUSKA_PACKAGE = "io.acionyx.tunguska"
         // Cap on concurrent Shizuku IPC calls during group freeze/unfreeze.
         // On Honor MagicOS parallel disable-user emits a flood of PACKAGE_REMOVED
         // broadcasts that overwhelms the stock launcher's grid repaint — 4 was
@@ -361,3 +396,5 @@ enum class StealthState {
     ENABLED,
     DISABLING
 }
+
+

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -121,7 +121,14 @@ class StealthOrchestrator(
             _lastError.value = "Подключите VPN вручную в ${client.displayName}"
         }
 
-        _state.value = StealthState.ENABLED
+        // Compare-and-set guards the race where VpnMonitorService.onLost fires on a
+        // binder thread between waitForVpnOn succeeding and this line — it would
+        // set _state=DISABLED via applyManagedStateForVpn(false), and a plain
+        // assignment here would clobber that correct update back to ENABLED.
+        // If _state is no longer ENABLING, someone else already wrote a definitive
+        // value (ENABLED from applyManagedStateForVpn(true), DISABLED from onLost,
+        // or DISABLED from fail elsewhere) — don't overwrite.
+        _state.compareAndSet(StealthState.ENABLING, StealthState.ENABLED)
     }
 
     /**

--- a/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
@@ -7,9 +7,7 @@ import android.service.quicksettings.TileService
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
-import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientManager
-import sgnv.anubis.app.vpn.VpnClientType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -39,10 +37,8 @@ class StealthTileService : TileService() {
         val repo = AppRepository(app.database.managedAppDao(), this)
         val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repo)
 
-        val prefs = AppSettings.prefs(this)
-        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
-            ?: VpnClientType.V2RAY_NG.packageName
-        val client = SelectedVpnClient.fromPackage(pkg)
+        // Tile uses the same selected client preference as the rest of the app.
+        val client = AppSettings.loadSelectedVpnClient(this)
 
         vpnClientManager.startMonitoringVpn()
 

--- a/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
@@ -5,9 +5,7 @@ import android.net.NetworkCapabilities
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import sgnv.anubis.app.AnubisApp
-import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
-import sgnv.anubis.app.vpn.VpnClientManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -33,14 +31,11 @@ class StealthTileService : TileService() {
 
         val app = application as AnubisApp
         val shizukuManager = app.shizukuManager
-        val vpnClientManager = VpnClientManager(this, shizukuManager)
-        val repo = AppRepository(app.database.managedAppDao(), this)
-        val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repo)
+        val vpnClientManager = app.vpnClientManager
+        val orchestrator = app.orchestrator
 
         // Tile uses the same selected client preference as the rest of the app.
         val client = AppSettings.loadSelectedVpnClient(this)
-
-        vpnClientManager.startMonitoringVpn()
 
         scope.launch {
             try {
@@ -63,8 +58,6 @@ class StealthTileService : TileService() {
                         VpnMonitorService.stop(this@StealthTileService)
                     }
                 }
-
-                vpnClientManager.stopMonitoringVpn()
             } finally {
                 updateTile()
             }

--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
@@ -5,10 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import sgnv.anubis.app.AnubisApp
-import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.vpn.SelectedVpnClient
-import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.VpnClientType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -40,9 +38,8 @@ class StealthWidgetService : Service() {
 
         val app = applicationContext as AnubisApp
         val shizukuManager = app.shizukuManager
-        val vpnClientManager = VpnClientManager(this, shizukuManager)
-        val repo = AppRepository(app.database.managedAppDao(), this)
-        val orchestrator = StealthOrchestrator(this, shizukuManager, vpnClientManager, repo)
+        val vpnClientManager = app.vpnClientManager
+        val orchestrator = app.orchestrator
 
         val prefs = AppSettings.prefs(this)
         val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
@@ -54,8 +51,6 @@ class StealthWidgetService : Service() {
             if (willBeActive) "Замораживаю..." else "Отключаю VPN...",
             StealthWidgetProvider.COLOR_WORKING
         )
-
-        vpnClientManager.startMonitoringVpn()
 
         scope.launch {
             try {
@@ -99,7 +94,6 @@ class StealthWidgetService : Service() {
                 }
 
                 progressJob.cancel()
-                vpnClientManager.stopMonitoringVpn()
             } finally {
                 // Always reset widget to real VPN state — covers normal completion,
                 // timeout, and any unexpected exception.

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -189,11 +189,24 @@ class VpnMonitorService : Service() {
                         }
                     }
                 }
+                freezeSelectedVpnClientIfNeeded()
             }
         } finally {
             // Always update widget to real VPN state — even if freeze/unfreeze timed out.
             StealthWidgetProvider.updateAllWidgets(applicationContext)
         }
+    }
+
+    private suspend fun freezeSelectedVpnClientIfNeeded() {
+        val packageName = AppSettings.prefs(applicationContext)
+            .getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
+            .orEmpty()
+        if (packageName != "io.acionyx.tunguska") return
+        val shizukuManager = (applicationContext as AnubisApp).shizukuManager
+        if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
+        shizukuManager.bindUserService()
+        kotlinx.coroutines.delay(200)
+        shizukuManager.freezeApp(packageName)
     }
 
     private fun buildNotification(): Notification {

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -29,6 +29,7 @@ import sgnv.anubis.app.R
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
+import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.ui.MainActivity
 
 /**
@@ -198,15 +199,13 @@ class VpnMonitorService : Service() {
     }
 
     private suspend fun freezeSelectedVpnClientIfNeeded() {
-        val packageName = AppSettings.prefs(applicationContext)
-            .getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
-            .orEmpty()
-        if (packageName != "io.acionyx.tunguska") return
+        val client = AppSettings.loadSelectedVpnClient(applicationContext)
+        val control = VpnClientControls.getControlForClient(client)
+        if (!control.freezeInIdle) return
         val shizukuManager = (applicationContext as AnubisApp).shizukuManager
         if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
-        shizukuManager.bindUserService()
-        kotlinx.coroutines.delay(200)
-        shizukuManager.freezeApp(packageName)
+        if (!shizukuManager.awaitUserService(500)) return
+        shizukuManager.freezeApp(client.packageName)
     }
 
     private fun buildNotification(): Notification {

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -15,30 +15,23 @@ import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.sync.withPermit
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
-import sgnv.anubis.app.data.model.AppGroup
-import sgnv.anubis.app.data.repository.AppRepository
-import sgnv.anubis.app.settings.AppSettings
-import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.ui.MainActivity
 
 /**
- * Foreground service that monitors VPN state changes and auto-freezes app groups.
+ * Foreground service that syncs stealth state with real VPN state while the UI is
+ * killed. Delegates all freeze/unfreeze and _state transitions to the shared
+ * StealthOrchestrator in AnubisApp — that way UI and service are backed by the
+ * same StateFlow and can't drift from each other.
  *
- * When VPN turns ON:  freezes LOCAL group
- * When VPN turns OFF: freezes VPN_ONLY group
+ * When VPN turns ON:  orchestrator.freezeOnly()  -> freezes LOCAL, sets ENABLED
+ * When VPN turns OFF: orchestrator.freezeVpnOnly() -> freezes VPN_ONLY, sets DISABLED
  *
- * This closes the gap where user toggles VPN outside of Anubis.
+ * This closes the gap where the user toggles VPN outside of Anubis.
  */
 class VpnMonitorService : Service() {
 
@@ -66,6 +59,7 @@ class VpnMonitorService : Service() {
         if (networkCallback != null) return
 
         val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
+        val app = applicationContext as AnubisApp
 
         val request = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
@@ -76,29 +70,36 @@ class VpnMonitorService : Service() {
             override fun onAvailable(network: Network) {
                 // Skip our own force-disconnect dummy VPN — treating it as "external VPN ON"
                 // would re-freeze groups that disable() just unfroze.
-                //
-                // Primary check: ownerUid. Stable, survives the "long-idle phantom VPN
-                // entry" case where Android still lists our dummy well past its
-                // onDestroy grace window.
-                // Fallback check: the time-based dummyVpnInFlight flag, in case
-                // ownerUid reads -1 for reasons outside our understanding.
                 if (isOwnVpnNetwork(cm, network)) return
                 if (StealthVpnService.dummyVpnInFlight) return
-                // VPN turned ON — freeze LOCAL group
-                scope.launch { applyManagedStateForVpn(active = true) }
+                scope.launch {
+                    withTimeoutOrNull(APPLY_STATE_TIMEOUT_MS) {
+                        app.orchestrator.freezeOnly()
+                    }
+                    StealthWidgetProvider.updateAllWidgets(applicationContext)
+                }
             }
 
             override fun onLost(network: Network) {
                 if (isOwnVpnNetwork(cm, network)) return
                 if (StealthVpnService.dummyVpnInFlight) return
-                // VPN turned OFF — freeze VPN_ONLY group
+                // Exclude the just-lost network: at the moment onLost is dispatched,
+                // the system may not have removed it from allNetworks yet. Without
+                // this, stillActive sees the dying network and we skip freezeVpnOnly
+                // — state gets stuck at ENABLED after external VPN crashes.
                 val stillActive = cm.allNetworks.any { n ->
+                    if (n == network) return@any false
                     val caps = cm.getNetworkCapabilities(n) ?: return@any false
                     caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) &&
                         caps.ownerUid != Process.myUid()
                 }
                 if (!stillActive) {
-                    scope.launch { applyManagedStateForVpn(active = false) }
+                    scope.launch {
+                        withTimeoutOrNull(APPLY_STATE_TIMEOUT_MS) {
+                            app.orchestrator.freezeVpnOnly()
+                        }
+                        StealthWidgetProvider.updateAllWidgets(applicationContext)
+                    }
                 }
             }
         }
@@ -122,90 +123,6 @@ class VpnMonitorService : Service() {
             } catch (_: Exception) {}
             networkCallback = null
         }
-    }
-
-    private suspend fun freezeGroup(group: AppGroup) {
-        val app = applicationContext as AnubisApp
-        val shizukuManager = app.shizukuManager
-        if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
-        shizukuManager.bindUserService()
-
-        val repo = AppRepository(app.database.managedAppDao(), applicationContext)
-        val packages = repo.getPackagesByGroup(group)
-        val sem = Semaphore(FREEZE_CONCURRENCY)
-        coroutineScope {
-            packages.map { pkg ->
-                async {
-                    sem.withPermit {
-                        if (shizukuManager.isAppInstalled(pkg) && !shizukuManager.isAppFrozen(pkg)) {
-                            shizukuManager.freezeApp(pkg)
-                        }
-                    }
-                }
-            }.awaitAll()
-        }
-    }
-
-    private suspend fun unfreezeGroup(group: AppGroup) {
-        val app = applicationContext as AnubisApp
-        val shizukuManager = app.shizukuManager
-        if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
-        shizukuManager.bindUserService()
-
-        val repo = AppRepository(app.database.managedAppDao(), applicationContext)
-        val packages = repo.getPackagesByGroup(group)
-        val sem = Semaphore(FREEZE_CONCURRENCY)
-        coroutineScope {
-            packages.map { pkg ->
-                async {
-                    sem.withPermit {
-                        if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
-                            shizukuManager.unfreezeApp(pkg)
-                        }
-                    }
-                }
-            }.awaitAll()
-        }
-    }
-
-    private suspend fun applyManagedStateForVpn(active: Boolean) {
-        val mutex = (applicationContext as AnubisApp).groupOpMutex
-        try {
-            // Hard ceiling: if freeze/unfreeze hangs (e.g. binder IPC stuck),
-            // withTimeoutOrNull cancels the lock holder and releases the mutex
-            // via withLock's finally block — preventing permanent mutex starvation.
-            withTimeoutOrNull(APPLY_STATE_TIMEOUT_MS) {
-                mutex.withLock {
-                    if (active) {
-                        freezeGroup(AppGroup.LOCAL)
-                        freezeGroup(AppGroup.LOCAL_AUTO_UNFREEZE)
-                        if (AppSettings.shouldUnfreezeManagedAppsOnVpnToggle(applicationContext)) {
-                            unfreezeGroup(AppGroup.VPN_ONLY)
-                        }
-                    } else {
-                        freezeGroup(AppGroup.VPN_ONLY)
-                        unfreezeGroup(AppGroup.LOCAL_AUTO_UNFREEZE)
-                        if (AppSettings.shouldUnfreezeManagedAppsOnVpnToggle(applicationContext)) {
-                            unfreezeGroup(AppGroup.LOCAL)
-                        }
-                    }
-                }
-                freezeSelectedVpnClientIfNeeded()
-            }
-        } finally {
-            // Always update widget to real VPN state — even if freeze/unfreeze timed out.
-            StealthWidgetProvider.updateAllWidgets(applicationContext)
-        }
-    }
-
-    private suspend fun freezeSelectedVpnClientIfNeeded() {
-        val client = AppSettings.loadSelectedVpnClient(applicationContext)
-        val control = VpnClientControls.getControlForClient(client)
-        if (!control.freezeInIdle) return
-        val shizukuManager = (applicationContext as AnubisApp).shizukuManager
-        if (!shizukuManager.isAvailable() || !shizukuManager.hasPermission()) return
-        if (!shizukuManager.awaitUserService(500)) return
-        shizukuManager.freezeApp(client.packageName)
     }
 
     private fun buildNotification(): Notification {
@@ -234,8 +151,6 @@ class VpnMonitorService : Service() {
         const val ACTION_START = "sgnv.anubis.app.START_MONITOR"
         const val ACTION_STOP = "sgnv.anubis.app.STOP_MONITOR"
         const val NOTIFICATION_ID = 1
-
-        private const val FREEZE_CONCURRENCY = 2
 
         // Per-binder-op timeout is 5 s (ShizukuManager.BINDER_OP_TIMEOUT_MS).
         // With FREEZE_CONCURRENCY=2 and up to ~30 managed apps, worst case

--- a/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
+++ b/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
@@ -2,20 +2,65 @@ package sgnv.anubis.app.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientType
 
 /** Centralized SharedPreferences keys for app-level settings. */
 object AppSettings {
     const val PREFS_NAME = "settings"
+    private const val SECURE_PREFS_NAME = "settings_secure"
     const val KEY_VPN_CLIENT_PACKAGE = "vpn_client_package"
     const val KEY_BACKGROUND_MONITORING = "background_monitoring"
     const val KEY_FREEZE_ON_BOOT = "freeze_on_boot"
     const val KEY_UNFREEZE_ON_VPN_TOGGLE = "unfreeze_on_vpn_toggle"
     private const val KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX = "vpn_client_automation_token_"
+    private const val TAG = "AppSettings"
+
+    @Volatile
+    private var securePrefsCache: SharedPreferences? = null
 
     fun prefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    private fun securePrefs(context: Context): SharedPreferences? {
+        securePrefsCache?.let { return it }
+        return synchronized(this) {
+            securePrefsCache?.let { return@synchronized it }
+            runCatching {
+                val appContext = context.applicationContext
+                val masterKey = MasterKey.Builder(appContext)
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build()
+                EncryptedSharedPreferences.create(
+                    appContext,
+                    SECURE_PREFS_NAME,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+                )
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to open encrypted preferences for VPN automation tokens", error)
+            }.getOrNull()?.also { securePrefsCache = it }
+        }
+    }
+
+    private fun automationTokenKey(packageName: String): String =
+        "$KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX$packageName"
+
+    private fun migrateLegacyAutomationTokenIfNeeded(context: Context, packageName: String): String? {
+        val key = automationTokenKey(packageName)
+        val securePrefs = securePrefs(context) ?: return null
+        securePrefs.getString(key, null)?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val legacyPrefs = prefs(context)
+        val legacyToken = legacyPrefs.getString(key, null)?.takeIf { it.isNotBlank() } ?: return null
+        securePrefs.edit().putString(key, legacyToken).apply()
+        legacyPrefs.edit().remove(key).apply()
+        return legacyToken
     }
 
     /** Optional behavior: unfreeze the opposite managed group after VPN state changes. */
@@ -24,20 +69,23 @@ object AppSettings {
     }
 
     fun getVpnClientAutomationToken(context: Context, packageName: String): String? {
-        return prefs(context)
-            .getString("$KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX$packageName", null)
+        return migrateLegacyAutomationTokenIfNeeded(context, packageName)
+            ?: securePrefs(context)
+            ?.getString(automationTokenKey(packageName), null)
             ?.takeIf { it.isNotBlank() }
     }
 
     fun setVpnClientAutomationToken(context: Context, packageName: String, token: String?) {
-        val editor = prefs(context).edit()
-        val key = "$KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX$packageName"
+        val securePrefs = securePrefs(context) ?: return
+        val editor = securePrefs.edit()
+        val key = automationTokenKey(packageName)
         if (token.isNullOrBlank()) {
             editor.remove(key)
         } else {
             editor.putString(key, token)
         }
         editor.apply()
+        prefs(context).edit().remove(key).apply()
     }
 
     fun loadSelectedVpnClient(

--- a/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
+++ b/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
@@ -2,6 +2,8 @@ package sgnv.anubis.app.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import sgnv.anubis.app.vpn.SelectedVpnClient
+import sgnv.anubis.app.vpn.VpnClientType
 
 /** Centralized SharedPreferences keys for app-level settings. */
 object AppSettings {
@@ -10,6 +12,7 @@ object AppSettings {
     const val KEY_BACKGROUND_MONITORING = "background_monitoring"
     const val KEY_FREEZE_ON_BOOT = "freeze_on_boot"
     const val KEY_UNFREEZE_ON_VPN_TOGGLE = "unfreeze_on_vpn_toggle"
+    private const val KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX = "vpn_client_automation_token_"
 
     fun prefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -18,5 +21,39 @@ object AppSettings {
     /** Optional behavior: unfreeze the opposite managed group after VPN state changes. */
     fun shouldUnfreezeManagedAppsOnVpnToggle(context: Context): Boolean {
         return prefs(context).getBoolean(KEY_UNFREEZE_ON_VPN_TOGGLE, false)
+    }
+
+    fun getVpnClientAutomationToken(context: Context, packageName: String): String? {
+        return prefs(context)
+            .getString("$KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX$packageName", null)
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    fun setVpnClientAutomationToken(context: Context, packageName: String, token: String?) {
+        val editor = prefs(context).edit()
+        val key = "$KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX$packageName"
+        if (token.isNullOrBlank()) {
+            editor.remove(key)
+        } else {
+            editor.putString(key, token)
+        }
+        editor.apply()
+    }
+
+    fun loadSelectedVpnClient(
+        context: Context,
+        packageNameOverride: String? = null,
+    ): SelectedVpnClient {
+        val prefs = prefs(context)
+        val packageName = packageNameOverride
+            ?: prefs.getString(KEY_VPN_CLIENT_PACKAGE, null)
+            ?: prefs.getString("vpn_client", null)?.let {
+                runCatching { VpnClientType.valueOf(it).packageName }.getOrNull()
+            }
+            ?: VpnClientType.V2RAY_NG.packageName
+        return SelectedVpnClient.fromPackage(
+            pkg = packageName,
+            automationToken = getVpnClientAutomationToken(context, packageName),
+        )
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
@@ -156,9 +156,10 @@ class ShizukuManager(private val packageManager: PackageManager) {
         userService = null
     }
 
-    suspend fun execShellCommand(vararg args: String): Result<Unit> = withContext(Dispatchers.IO) {
-        runCommand(*args)
-    }
+    suspend fun execShellCommand(vararg args: String): Result<Unit> =
+        withTimeoutOrNull(SHELL_CMD_TIMEOUT_MS) {
+            withContext(Dispatchers.IO) { runCommand(*args) }
+        } ?: Result.failure(RuntimeException("execShellCommand timed out: ${args.joinToString(" ")}"))
 
     /**
      * Force-stops a package via `IActivityManager.forceStopPackage` through a Shizuku-wrapped
@@ -166,9 +167,10 @@ class ShizukuManager(private val packageManager: PackageManager) {
      * (HyperOS / HiOS / MIUI) runs inside a restricted shell environment where it silently
      * no-ops. Binder IPC is not touched by OEM shell sandboxes.
      */
-    suspend fun forceStopApp(packageName: String): Result<Unit> = withContext(Dispatchers.IO) {
-        forceStopInternal(packageName)
-    }
+    suspend fun forceStopApp(packageName: String): Result<Unit> =
+        withTimeoutOrNull(BINDER_OP_TIMEOUT_MS) {
+            withContext(Dispatchers.IO) { forceStopInternal(packageName) }
+        } ?: Result.failure(RuntimeException("forceStopApp timed out: $packageName"))
 
     /**
      * Freezes a package by calling `IPackageManager.setApplicationEnabledSetting(DISABLED_USER)`
@@ -221,14 +223,17 @@ class ShizukuManager(private val packageManager: PackageManager) {
     /**
      * Run a shell command and return its stdout output.
      */
-    suspend fun runCommandWithOutput(vararg args: String): String? = withContext(Dispatchers.IO) {
-        try {
-            val service = userService ?: return@withContext null
-            service.execCommandWithOutput(args.toList().toTypedArray())
-        } catch (e: Exception) {
-            null
+    suspend fun runCommandWithOutput(vararg args: String): String? =
+        withTimeoutOrNull(SHELL_CMD_TIMEOUT_MS) {
+            withContext(Dispatchers.IO) {
+                try {
+                    val service = userService ?: return@withContext null
+                    service.execCommandWithOutput(args.toList().toTypedArray())
+                } catch (e: Exception) {
+                    null
+                }
+            }
         }
-    }
 
     private fun runCommand(vararg args: String): Result<Unit> {
         return try {
@@ -301,6 +306,14 @@ class ShizukuManager(private val packageManager: PackageManager) {
          * to prevent the groupOpMutex from being held indefinitely on a hung call.
          */
         private const val BINDER_OP_TIMEOUT_MS = 5_000L
+
+        /**
+         * Shell commands forwarded through the Shizuku UserService binder. Typical durations:
+         * `am broadcast` / `am start` < 1 s, `dumpsys connectivity` 1–3 s on busy devices.
+         * 10 s caps the rare case where the UserService binder stalls — otherwise
+         * orchestrator.enable/disable would hang inside startVPN/detectActiveVpnClient.
+         */
+        private const val SHELL_CMD_TIMEOUT_MS = 10_000L
 
         /**
          * Main user ID for this process. For app UIDs Android encodes userId as `uid / 100_000`

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -175,8 +175,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             } else if (stealthState.value == StealthState.ENABLED) {
                 val detectedPkg = vpnClientManager.activeVpnPackage.value
                 val detectedClient = vpnClientManager.activeVpnClient.value
-                val clientToStop = if (detectedClient != null) SelectedVpnClient.fromKnown(detectedClient)
-                    else vpnClientManager.activeVpnPackage.value?.let { SelectedVpnClient.fromPackage(it) }
+                val clientToStop = if (detectedClient != null) {
+                    AppSettings.loadSelectedVpnClient(getApplication(), detectedClient.packageName)
+                } else vpnClientManager.activeVpnPackage.value?.let {
+                    AppSettings.loadSelectedVpnClient(getApplication(), it)
+                }
                     ?: _selectedVpnClient.value
                 orchestrator.disable(clientToStop, detectedPkg)
                 if (orchestrator.state.value == StealthState.DISABLED) {
@@ -199,8 +202,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val detectedPkg = vpnClientManager.activeVpnPackage.value
             val detectedClient = vpnClientManager.activeVpnClient.value
-            val clientToStop = if (detectedClient != null) SelectedVpnClient.fromKnown(detectedClient)
-                else detectedPkg?.let { SelectedVpnClient.fromPackage(it) }
+            val clientToStop = if (detectedClient != null) {
+                AppSettings.loadSelectedVpnClient(getApplication(), detectedClient.packageName)
+            } else detectedPkg?.let {
+                AppSettings.loadSelectedVpnClient(getApplication(), it)
+            }
                 ?: _selectedVpnClient.value
             orchestrator.launchLocal(packageName, clientToStop, detectedPkg)
             if (orchestrator.state.value == StealthState.DISABLED) {
@@ -428,11 +434,27 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun selectVpnClient(client: SelectedVpnClient) {
-        _selectedVpnClient.value = client
+        val persistedClient = AppSettings.loadSelectedVpnClient(getApplication(), client.packageName)
+        _selectedVpnClient.value = client.copy(
+            automationToken = client.automationToken ?: persistedClient.automationToken,
+        )
         AppSettings.prefs(getApplication())
             .edit {
                 putString(AppSettings.KEY_VPN_CLIENT_PACKAGE, client.packageName)
             }
+    }
+
+    fun updateSelectedVpnClientAutomationToken(token: String) {
+        val normalizedToken = token.trim()
+        val current = _selectedVpnClient.value
+        AppSettings.setVpnClientAutomationToken(
+            getApplication(),
+            current.packageName,
+            normalizedToken.takeIf { it.isNotEmpty() },
+        )
+        _selectedVpnClient.value = current.copy(
+            automationToken = normalizedToken.takeIf { it.isNotEmpty() },
+        )
     }
 
     fun isVpnClientEnabled(packageName: String): Boolean {
@@ -585,19 +607,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private fun loadSelectedClient() {
-        val prefs = AppSettings.prefs(getApplication())
-        val pkg = prefs.getString(AppSettings.KEY_VPN_CLIENT_PACKAGE, null)
-            ?: prefs.getString("vpn_client", null)?.let {
-                // Migration from old format (enum name → package name)
-                try { VpnClientType.valueOf(it).packageName } catch (e: Exception) { null }
-            }
-        _selectedVpnClient.value = if (pkg != null) {
-            SelectedVpnClient.fromPackage(pkg)
-        } else {
-            SelectedVpnClient.fromKnown(VpnClientType.V2RAY_NG)
-        }
+        _selectedVpnClient.value = AppSettings.loadSelectedVpnClient(getApplication())
     }
-
     private fun loadUpdateCheckPref() {
         _updateCheckEnabled.value = UpdateChecker.isEnabled(getApplication())
     }
@@ -641,3 +652,4 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         super.onCleared()
     }
 }
+

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -9,8 +9,6 @@ import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.InstalledAppInfo
 import sgnv.anubis.app.data.model.ManagedApp
 import sgnv.anubis.app.data.model.NetworkInfo
-import sgnv.anubis.app.data.repository.AppRepository
-import sgnv.anubis.app.service.StealthOrchestrator
 import sgnv.anubis.app.service.StealthState
 import sgnv.anubis.app.service.StealthVpnService
 import sgnv.anubis.app.service.VpnMonitorService
@@ -19,7 +17,6 @@ import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.update.UpdateChecker
 import sgnv.anubis.app.update.UpdateInfo
 import sgnv.anubis.app.vpn.SelectedVpnClient
-import sgnv.anubis.app.vpn.VpnClientManager
 import sgnv.anubis.app.vpn.VpnClientType
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
@@ -46,9 +43,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val app = application as AnubisApp
     val shizukuManager = app.shizukuManager
-    private val vpnClientManager = VpnClientManager(application, shizukuManager)
-    private val repository = AppRepository(app.database.managedAppDao(), application)
-    private val orchestrator = StealthOrchestrator(application, shizukuManager, vpnClientManager, repository)
+    private val vpnClientManager = app.vpnClientManager
+    private val repository = app.appRepository
+    private val orchestrator = app.orchestrator
 
     val stealthState: StateFlow<StealthState> = orchestrator.state
     val lastError: StateFlow<String?> = orchestrator.lastError
@@ -118,7 +115,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val resetCompleted: SharedFlow<Int> = _resetCompleted
 
     init {
-        vpnClientManager.startMonitoringVpn()
+        // VpnClientManager is started in AnubisApp.onCreate — don't re-register here.
         refreshVpnClients()
         loadSelectedClient()
         loadInstalledApps()
@@ -636,7 +633,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     override fun onCleared() {
-        vpnClientManager.stopMonitoringVpn()
+        // VpnClientManager is a process-wide singleton in AnubisApp — don't stop it here.
         super.onCleared()
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import sgnv.anubis.app.ui.MainViewModel
 import sgnv.anubis.app.vpn.SelectedVpnClient
@@ -259,6 +260,27 @@ fun VpnClientScreen(
                             RadioButton(selected = true, onClick = null)
                         }
                     }
+                }
+            }
+
+            if (selectedClient.packageName == VpnClientType.TUNGUSKA.packageName) {
+                item(key = "tunguska_token") {
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedTextField(
+                        value = selectedClient.automationToken.orEmpty(),
+                        onValueChange = viewModel::updateSelectedVpnClientAutomationToken,
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        label = { Text("Automation token") },
+                        placeholder = { Text("Paste the Tunguska automation token") },
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Required for Tunguska start and stop commands.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
 

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -67,7 +69,9 @@ fun VpnClientScreen(
 
     var searchActive by rememberSaveable { mutableStateOf(false) }
     var query by rememberSaveable { mutableStateOf("") }
+    var otherAppsExpanded by rememberSaveable { mutableStateOf(false) }
     val normalizedQuery = query.trim()
+    val showOtherApps = otherAppsExpanded || (searchActive && normalizedQuery.isNotBlank())
     val focusRequester = remember { FocusRequester() }
 
     val grouped = remember(normalizedQuery) {
@@ -200,17 +204,26 @@ fun VpnClientScreen(
                     } else {
                         val client = installedVariants.firstOrNull() ?: variants.first()
                         val isInstalled = installedClients.contains(client)
-                        VpnClientTile(
-                            client = client,
-                            label = client.fullDisplayName,
-                            isInstalled = isInstalled,
-                            isSelected = selectedClient.packageName == client.packageName,
-                            isFrozen = isInstalled && !viewModel.isVpnClientEnabled(client.packageName),
-                            onClick = {
-                                if (isInstalled) viewModel.selectVpnClient(SelectedVpnClient.fromKnown(client))
-                            },
-                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
-                        )
+                        val isThisSelected = selectedClient.packageName == client.packageName
+                        Column {
+                            VpnClientTile(
+                                client = client,
+                                label = client.fullDisplayName,
+                                isInstalled = isInstalled,
+                                isSelected = isThisSelected,
+                                isFrozen = isInstalled && !viewModel.isVpnClientEnabled(client.packageName),
+                                onClick = {
+                                    if (isInstalled) viewModel.selectVpnClient(SelectedVpnClient.fromKnown(client))
+                                },
+                                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                            )
+                            if (isThisSelected && client == VpnClientType.TUNGUSKA) {
+                                TunguskaTokenPanel(
+                                    token = selectedClient.automationToken.orEmpty(),
+                                    onTokenChange = viewModel::updateSelectedVpnClientAutomationToken,
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -219,16 +232,29 @@ fun VpnClientScreen(
                 Spacer(Modifier.height(16.dp))
                 HorizontalDivider()
                 Spacer(Modifier.height(8.dp))
-                Text(
-                    "Другой клиент",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    "Любое установленное приложение (ручной режим)",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().clickable {
+                        otherAppsExpanded = !otherAppsExpanded
+                    },
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            "Другой клиент",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            "Любое установленное приложение (ручной режим)",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Icon(
+                        if (showOtherApps) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = if (showOtherApps) "Свернуть" else "Развернуть",
+                    )
+                }
                 Spacer(Modifier.height(8.dp))
             }
 
@@ -263,28 +289,7 @@ fun VpnClientScreen(
                 }
             }
 
-            if (selectedClient.packageName == VpnClientType.TUNGUSKA.packageName) {
-                item(key = "tunguska_token") {
-                    Spacer(Modifier.height(12.dp))
-                    OutlinedTextField(
-                        value = selectedClient.automationToken.orEmpty(),
-                        onValueChange = viewModel::updateSelectedVpnClientAutomationToken,
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        label = { Text("Automation token") },
-                        placeholder = { Text("Paste the Tunguska automation token") },
-                        visualTransformation = PasswordVisualTransformation(),
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        "Required for Tunguska start and stop commands.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-
-            items(otherApps, key = { "app_${it.packageName}" }) { app ->
+            if (showOtherApps) items(otherApps, key = { "app_${it.packageName}" }) { app ->
                 val iconBitmap = remember(app.packageName) {
                     try {
                         val drawable = pm.getApplicationIcon(app.packageName)
@@ -328,6 +333,63 @@ fun VpnClientScreen(
                         RadioButton(selected = true, onClick = null)
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TunguskaTokenPanel(
+    token: String,
+    onTokenChange: (String) -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(token.isBlank()) }
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable { expanded = !expanded },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        "Токен автоматизации",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    Text(
+                        if (token.isBlank()) "Не задан" else "Задан",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (token.isBlank()) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Icon(
+                    if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = if (expanded) "Свернуть" else "Развернуть",
+                )
+            }
+            if (expanded) {
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = token,
+                    onValueChange = onTokenChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    label = { Text("Токен") },
+                    placeholder = { Text("Вставьте токен автоматизации Tunguska") },
+                    visualTransformation = PasswordVisualTransformation(),
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Требуется для команд запуска и остановки Tunguska.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClient.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClient.kt
@@ -72,12 +72,14 @@ enum class VpnControlMode { SEPARATE, TOGGLE, MANUAL }
 data class VpnClientControl(
     val clientType: VpnClientType,
     val mode: VpnControlMode,
+    val freezeInIdle: Boolean = false,
     /** Shell command to start VPN (SEPARATE/TOGGLE). Null for MANUAL. */
     val startCommand: Array<String>? = null,
     /** Shell command to stop VPN. Only for SEPARATE mode. */
     val stopCommand: Array<String>? = null,
     val startCommandBuilder: ((SelectedVpnClient) -> Array<String>?)? = null,
     val stopCommandBuilder: ((SelectedVpnClient) -> Array<String>?)? = null,
+    val startCommandFailureMessageBuilder: ((SelectedVpnClient) -> String?)? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -92,6 +94,9 @@ data class VpnClientControl(
 
     fun buildStopCommand(client: SelectedVpnClient): Array<String>? =
         stopCommandBuilder?.invoke(client) ?: stopCommand
+
+    fun buildStartCommandFailureMessage(client: SelectedVpnClient): String? =
+        startCommandFailureMessageBuilder?.invoke(client)
 }
 
 object VpnClientControls {
@@ -288,6 +293,7 @@ object VpnClientControls {
         VpnClientType.TUNGUSKA to VpnClientControl(
             clientType = VpnClientType.TUNGUSKA,
             mode = VpnControlMode.SEPARATE,
+            freezeInIdle = true,
             startCommandBuilder = { client ->
                 client.automationToken?.takeIf { it.isNotBlank() }?.let { token ->
                     arrayOf(
@@ -297,6 +303,13 @@ object VpnClientControls {
                         "--es", "automation_token", token,
                         "--es", "caller_hint", "anubis",
                     )
+                }
+            },
+            startCommandFailureMessageBuilder = { client ->
+                if (client.automationToken.isNullOrBlank()) {
+                    "Не задан токен автоматизации Tunguska. Укажите его в настройках VPN клиента."
+                } else {
+                    null
                 }
             },
             stopCommandBuilder = { client ->

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClient.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClient.kt
@@ -20,6 +20,7 @@ enum class VpnClientType(
     OLCNG("GitHub", "xyz.zarazaex.olc", brand = "olcng"),
     OLCNG_FDROID("F-Droid", "xyz.zarazaex.olc.fdroid", brand = "olcng"),
     TEAPOD_STREAM("TeapodStream", "com.teapodstream.teapodstream"),
+    TUNGUSKA("Tunguska", "io.acionyx.tunguska"),
     KARING("Karing", "com.nebula.karing"),
     AMNEZIA_VPN("VPN", "org.amnezia.vpn", brand = "Amnezia"),
     AMNEZIA_WG("WG", "org.amnezia.awg", brand = "Amnezia"),
@@ -42,7 +43,8 @@ enum class VpnClientType(
  */
 data class SelectedVpnClient(
     val knownType: VpnClientType? = null,
-    val packageName: String
+    val packageName: String,
+    val automationToken: String? = null,
 ) {
     val displayName: String
         get() = knownType?.fullDisplayName ?: packageName.substringAfterLast('.')
@@ -51,8 +53,11 @@ data class SelectedVpnClient(
         get() = if (knownType != null) VpnClientControls.getControl(knownType).mode else VpnControlMode.MANUAL
 
     companion object {
-        fun fromKnown(type: VpnClientType) = SelectedVpnClient(type, type.packageName)
-        fun fromPackage(pkg: String) = SelectedVpnClient(VpnClientType.fromPackageName(pkg), pkg)
+        fun fromKnown(type: VpnClientType, automationToken: String? = null) =
+            SelectedVpnClient(type, type.packageName, automationToken)
+
+        fun fromPackage(pkg: String, automationToken: String? = null) =
+            SelectedVpnClient(VpnClientType.fromPackageName(pkg), pkg, automationToken)
     }
 }
 
@@ -71,6 +76,8 @@ data class VpnClientControl(
     val startCommand: Array<String>? = null,
     /** Shell command to stop VPN. Only for SEPARATE mode. */
     val stopCommand: Array<String>? = null,
+    val startCommandBuilder: ((SelectedVpnClient) -> Array<String>?)? = null,
+    val stopCommandBuilder: ((SelectedVpnClient) -> Array<String>?)? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -79,6 +86,12 @@ data class VpnClientControl(
     }
 
     override fun hashCode() = clientType.hashCode()
+
+    fun buildStartCommand(client: SelectedVpnClient): Array<String>? =
+        startCommandBuilder?.invoke(client) ?: startCommand
+
+    fun buildStopCommand(client: SelectedVpnClient): Array<String>? =
+        stopCommandBuilder?.invoke(client) ?: stopCommand
 }
 
 object VpnClientControls {
@@ -272,6 +285,32 @@ object VpnClientControls {
             clientType = VpnClientType.TEAPOD_STREAM,
             mode = VpnControlMode.MANUAL,
         ),
+        VpnClientType.TUNGUSKA to VpnClientControl(
+            clientType = VpnClientType.TUNGUSKA,
+            mode = VpnControlMode.SEPARATE,
+            startCommandBuilder = { client ->
+                client.automationToken?.takeIf { it.isNotBlank() }?.let { token ->
+                    arrayOf(
+                        "am", "start", "-W",
+                        "-n", "io.acionyx.tunguska/.app.AutomationRelayActivity",
+                        "-a", "io.acionyx.tunguska.action.AUTOMATION_START",
+                        "--es", "automation_token", token,
+                        "--es", "caller_hint", "anubis",
+                    )
+                }
+            },
+            stopCommandBuilder = { client ->
+                client.automationToken?.takeIf { it.isNotBlank() }?.let { token ->
+                    arrayOf(
+                        "am", "start", "-W",
+                        "-n", "io.acionyx.tunguska/.app.AutomationRelayActivity",
+                        "-a", "io.acionyx.tunguska.action.AUTOMATION_STOP",
+                        "--es", "automation_token", token,
+                        "--es", "caller_hint", "anubis",
+                    )
+                }
+            },
+        ),
         // AmneziaVPN (Qt): no exported broadcast/activity API for start/stop — only QS Tile
         // and MainActivity. Fall back to MANUAL (open app, user taps connect).
         VpnClientType.AMNEZIA_VPN to VpnClientControl(
@@ -314,11 +353,15 @@ object VpnClientControls {
 
     fun getControl(type: VpnClientType): VpnClientControl = controls[type]!!
 
-    fun getControlForPackage(packageName: String): VpnClientControl {
-        val type = VpnClientType.fromPackageName(packageName)
+    fun getControlForClient(client: SelectedVpnClient): VpnClientControl {
+        val type = client.knownType ?: VpnClientType.fromPackageName(client.packageName)
         return if (type != null) controls[type]!! else VpnClientControl(
-            clientType = VpnClientType.V2RAY_NG, // placeholder, unused for MANUAL
+            clientType = VpnClientType.V2RAY_NG,
             mode = VpnControlMode.MANUAL
         )
+    }
+
+    fun getControlForPackage(packageName: String): VpnClientControl {
+        return getControlForClient(SelectedVpnClient.fromPackage(packageName))
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
@@ -62,10 +62,14 @@ class VpnClientManager(
     suspend fun startVPN(client: SelectedVpnClient) {
         val knownType = client.knownType
         if (knownType != null) {
-            val control = VpnClientControls.getControl(knownType)
+            val control = VpnClientControls.getControlForClient(client)
             when (control.mode) {
                 VpnControlMode.SEPARATE -> {
-                    val cmd = control.startCommand ?: return
+                    val cmd = control.buildStartCommand(client)
+                    if (cmd == null) {
+                        launchApp(client.packageName)
+                        return
+                    }
                     // Shell commands need UserService — binder freeze before us didn't.
                     shizukuManager.awaitUserService(2000)
                     val result = shizukuManager.execShellCommand(*cmd)
@@ -76,7 +80,7 @@ class VpnClientManager(
                 }
                 VpnControlMode.TOGGLE -> {
                     if (!_vpnActive.value) {
-                        val cmd = control.startCommand ?: return
+                        val cmd = control.buildStartCommand(client) ?: return
                         shizukuManager.awaitUserService(2000)
                         val result = shizukuManager.execShellCommand(*cmd)
                         if (result.isFailure) {
@@ -96,17 +100,17 @@ class VpnClientManager(
     suspend fun stopVPN(client: SelectedVpnClient) {
         val knownType = client.knownType
         if (knownType != null) {
-            val control = VpnClientControls.getControl(knownType)
+            val control = VpnClientControls.getControlForClient(client)
             when (control.mode) {
                 VpnControlMode.SEPARATE -> {
-                    val cmd = control.stopCommand ?: return
+                    val cmd = control.buildStopCommand(client) ?: return
                     shizukuManager.awaitUserService(2000)
                     val result = shizukuManager.execShellCommand(*cmd)
                     if (result.isFailure) Log.w(TAG, "Stop failed for ${client.displayName}", result.exceptionOrNull())
                 }
                 VpnControlMode.TOGGLE -> {
                     if (_vpnActive.value) {
-                        val cmd = control.startCommand ?: return
+                        val cmd = control.buildStartCommand(client) ?: return
                         shizukuManager.awaitUserService(2000)
                         val result = shizukuManager.execShellCommand(*cmd)
                         if (result.isFailure) Log.w(TAG, "Toggle-stop failed for ${client.displayName}", result.exceptionOrNull())

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
@@ -59,7 +59,7 @@ class VpnClientManager(
      * For TOGGLE: sends toggle only if VPN is currently off.
      * For MANUAL: just opens the app.
      */
-    suspend fun startVPN(client: SelectedVpnClient) {
+    suspend fun startVPN(client: SelectedVpnClient): String? {
         val knownType = client.knownType
         if (knownType != null) {
             val control = VpnClientControls.getControlForClient(client)
@@ -67,11 +67,16 @@ class VpnClientManager(
                 VpnControlMode.SEPARATE -> {
                     val cmd = control.buildStartCommand(client)
                     if (cmd == null) {
+                        val controlError = control.buildStartCommandFailureMessage(client)
+                        if (controlError != null) {
+                            Log.w(TAG, controlError)
+                            return controlError
+                        }
                         launchApp(client.packageName)
-                        return
+                        return null
                     }
                     // Shell commands need UserService — binder freeze before us didn't.
-                    shizukuManager.awaitUserService(2000)
+                    shizukuManager.awaitUserService(500)
                     val result = shizukuManager.execShellCommand(*cmd)
                     if (result.isFailure) {
                         Log.w(TAG, "Start failed for ${client.displayName}", result.exceptionOrNull())
@@ -80,8 +85,17 @@ class VpnClientManager(
                 }
                 VpnControlMode.TOGGLE -> {
                     if (!_vpnActive.value) {
-                        val cmd = control.buildStartCommand(client) ?: return
-                        shizukuManager.awaitUserService(2000)
+                        val cmd = control.buildStartCommand(client)
+                        if (cmd == null) {
+                            val controlError = control.buildStartCommandFailureMessage(client)
+                            if (controlError != null) {
+                                Log.w(TAG, controlError)
+                                return controlError
+                            }
+                            launchApp(client.packageName)
+                            return null
+                        }
+                        shizukuManager.awaitUserService(500)
                         val result = shizukuManager.execShellCommand(*cmd)
                         if (result.isFailure) {
                             Log.w(TAG, "Toggle-start failed for ${client.displayName}", result.exceptionOrNull())
@@ -95,6 +109,7 @@ class VpnClientManager(
             // Custom / unknown client — just open it
             launchApp(client.packageName)
         }
+        return null
     }
 
     suspend fun stopVPN(client: SelectedVpnClient) {
@@ -104,14 +119,14 @@ class VpnClientManager(
             when (control.mode) {
                 VpnControlMode.SEPARATE -> {
                     val cmd = control.buildStopCommand(client) ?: return
-                    shizukuManager.awaitUserService(2000)
+                    shizukuManager.awaitUserService(500)
                     val result = shizukuManager.execShellCommand(*cmd)
                     if (result.isFailure) Log.w(TAG, "Stop failed for ${client.displayName}", result.exceptionOrNull())
                 }
                 VpnControlMode.TOGGLE -> {
                     if (_vpnActive.value) {
                         val cmd = control.buildStartCommand(client) ?: return
-                        shizukuManager.awaitUserService(2000)
+                        shizukuManager.awaitUserService(500)
                         val result = shizukuManager.execShellCommand(*cmd)
                         if (result.isFailure) Log.w(TAG, "Toggle-stop failed for ${client.displayName}", result.exceptionOrNull())
                     }

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
@@ -154,7 +154,10 @@ class VpnClientManager(
             }
 
             override fun onLost(network: Network) {
-                val stillActive = isVpnCurrentlyActive(cm)
+                // Exclude the just-lost network: at the moment onLost is dispatched,
+                // the system may not have removed it from allNetworks yet, so without
+                // this the check sees the dying network and _vpnActive stays true.
+                val stillActive = isVpnCurrentlyActive(cm, exclude = network)
                 _vpnActive.value = stillActive
                 if (!stillActive) {
                     _activeVpnClient.value = null
@@ -273,15 +276,17 @@ class VpnClientManager(
         return null
     }
 
-    private fun isVpnCurrentlyActive(cm: ConnectivityManager): Boolean {
+    private fun isVpnCurrentlyActive(cm: ConnectivityManager, exclude: Network? = null): Boolean {
         // Don't gate on dummyVpnInFlight here: orchestrator.waitForVpnOff() relies on this
         // to see the real picture. If we pretend no VPN is active while our dummy + the
         // external VPN are both in the list, waitForVpnOff returns true instantly,
         // Step 3 force-stop is skipped, and launchLocal proceeds with the external VPN
         // still running (regression in v0.1.4, issue #63). The dummy-vs-external
         // distinction is only needed in VpnMonitorService — see the guard there.
+        // `exclude` is used by onLost to skip the network being lost (see callsite).
         return try {
             cm.allNetworks.any { network ->
+                if (network == exclude) return@any false
                 cm.getNetworkCapabilities(network)
                     ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
             }


### PR DESCRIPTION
## What changed

- adds Tunguska as a first-class known VPN client
- persists a per-package Tunguska automation token in encrypted preferences and migrates any earlier plaintext token on first access
- builds Tunguska start and stop commands from the selected client state instead of hard-coded static arrays
- shows the Tunguska token field only when Tunguska is selected in the VPN client picker
- keeps Tunguska frozen while idle, unfreezes it before start, and refreezes it after confirmed VPN shutdown
- rebases the integration onto current main while preserving the existing UserService wait path in the client manager and the shared selected-client loading path in the tile service

## Why

Tunguska exposes a token-gated explicit activity API instead of an open broadcast receiver. Anubis needs just enough client-specific state to pass that token to the right command path and to preserve the idle freeze model around start and stop.

That token is sensitive because possession is sufficient to invoke Tunguska's automation activity. This revision now stores the token in EncryptedSharedPreferences and removes any legacy plaintext copy from the general settings store during migration.

This revision intentionally keeps the Anubis-side diff focused. There is no marker-file polling, no extra integration AndroidTest in this PR, and no added logging beyond the existing manager warnings.

## Validation

- local build: :app:assembleDebug
- rebased onto current main and resolved the remaining conflicts in StealthTileService and VpnClientManager
- Tunguska side was validated separately on the split x86_64 emulator build with real Chrome IP proof and full-tunnel helper proof
- this PR keeps the Anubis-side diff focused on command construction, secure token persistence, and freeze lifecycle only