### PR TITLE
[Lint] Standardize KTX usage and remove redundant imports

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
@@ -1,6 +1,5 @@
 package sgnv.anubis.app.service
 
-import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import sgnv.anubis.app.AnubisApp

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -62,7 +62,7 @@ class VpnMonitorService : Service() {
     private fun startVpnMonitoring() {
         if (networkCallback != null) return
 
-        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
 
         val request = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
@@ -99,7 +99,7 @@ class VpnMonitorService : Service() {
     private fun stopVpnMonitoring() {
         networkCallback?.let {
             try {
-                val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
                 cm.unregisterNetworkCallback(it)
             } catch (_: Exception) {}
             networkCallback = null

--- a/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
@@ -1,6 +1,5 @@
 package sgnv.anubis.app.ui
 
-import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -41,7 +40,7 @@ class MainActivity : ComponentActivity() {
     private val vpnPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        if (result.resultCode == Activity.RESULT_OK) {
+        if (result.resultCode == RESULT_OK) {
             // VPN permission granted — now proceed with stealth toggle
             viewModelRef?.toggleStealth()
         }

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -25,7 +25,8 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
-import android.graphics.Bitmap
+import androidx.core.graphics.createBitmap
+import androidx.core.content.edit
 import android.graphics.Canvas
 import android.graphics.drawable.Icon
 import android.graphics.drawable.AdaptiveIconDrawable
@@ -235,10 +236,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 .roundToInt()
                 .coerceAtLeast(1)
 
-            val bmp = Bitmap.createBitmap(
-                fullSize,
-                fullSize,
-                Bitmap.Config.ARGB_8888)
+            val bmp = createBitmap(fullSize, fullSize)
             val canvas = Canvas(bmp)
             drawable.background?.let { bg ->
                 bg.setBounds(0, 0, fullSize, fullSize)
@@ -250,10 +248,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
             Icon.createWithAdaptiveBitmap(bmp)
         } else {
-            val bmp = Bitmap.createBitmap(
-                visibleSize,
-                visibleSize,
-                Bitmap.Config.ARGB_8888)
+            val bmp = createBitmap(visibleSize, visibleSize)
             val canvas = Canvas(bmp)
             drawable.setBounds(0, 0, visibleSize, visibleSize)
             drawable.draw(canvas)
@@ -401,9 +396,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun selectVpnClient(client: SelectedVpnClient) {
         _selectedVpnClient.value = client
         AppSettings.prefs(getApplication())
-            .edit()
-            .putString(AppSettings.KEY_VPN_CLIENT_PACKAGE, client.packageName)
-            .apply()
+            .edit {
+                putString(AppSettings.KEY_VPN_CLIENT_PACKAGE, client.packageName)
+            }
     }
 
     fun isVpnClientEnabled(packageName: String): Boolean {
@@ -416,9 +411,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _backgroundMonitoring.value = enabled
         val app = getApplication<Application>()
         AppSettings.prefs(app)
-            .edit()
-            .putBoolean(AppSettings.KEY_BACKGROUND_MONITORING, enabled)
-            .apply()
+            .edit {
+                putBoolean(AppSettings.KEY_BACKGROUND_MONITORING, enabled)
+            }
         if (enabled) {
             VpnMonitorService.start(app)
         } else {
@@ -439,9 +434,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _unfreezeManagedAppsOnVpnToggle.value = enabled
         // Persist immediately so orchestrators and services pick the flag up without restart.
         AppSettings.prefs(getApplication())
-            .edit()
-            .putBoolean(AppSettings.KEY_UNFREEZE_ON_VPN_TOGGLE, enabled)
-            .apply()
+            .edit {
+                putBoolean(AppSettings.KEY_UNFREEZE_ON_VPN_TOGGLE, enabled)
+            }
     }
 
     private fun loadUnfreezeManagedAppsOnVpnToggle() {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
@@ -1,6 +1,5 @@
 package sgnv.anubis.app.ui.screens
 
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.widget.Toast
 import androidx.compose.foundation.Image
@@ -43,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.ui.MainViewModel
+import androidx.core.graphics.createBitmap
 
 /**
  * Bottom sheet for inline add-to-group flow on the Home screen.
@@ -130,10 +130,9 @@ fun AddAppSheet(
                     val iconBitmap = remember(app.packageName) {
                         try {
                             val drawable = pm.getApplicationIcon(app.packageName)
-                            val bmp = Bitmap.createBitmap(
+                            val bmp = createBitmap(
                                 drawable.intrinsicWidth.coerceAtLeast(1),
-                                drawable.intrinsicHeight.coerceAtLeast(1),
-                                Bitmap.Config.ARGB_8888
+                                drawable.intrinsicHeight.coerceAtLeast(1)
                             )
                             val canvas = Canvas(bmp)
                             drawable.setBounds(0, 0, canvas.width, canvas.height)

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
@@ -1,8 +1,9 @@
 package sgnv.anubis.app.ui.screens
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Canvas
+import androidx.core.content.edit
+import androidx.core.graphics.createBitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -25,7 +26,6 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -316,7 +316,7 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
             },
             confirmButton = {
                 TextButton(onClick = {
-                    prefs.edit().putBoolean("seen_first_add_warning", true).apply()
+                    prefs.edit { putBoolean("seen_first_add_warning", true) }
                     viewModel.cycleAppGroup(pkg)
                     pendingFirstAdd = null
                 }) { Text("Добавить") }
@@ -342,7 +342,7 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
             },
             confirmButton = {
                 TextButton(onClick = {
-                    prefs.edit().putBoolean("seen_auto_warning", true).apply()
+                    prefs.edit { putBoolean("seen_auto_warning", true)}
                     showAutoWarning = false
                     viewModel.autoSelectRestricted()
                 }) { Text("Заморозить") }
@@ -390,11 +390,11 @@ private fun AppRow(app: InstalledAppInfo, isKnownRestricted: Boolean, onCycleGro
     val iconBitmap = remember(app.packageName) {
         try {
             val drawable = pm.getApplicationIcon(app.packageName)
-            val bmp = Bitmap.createBitmap(
-                drawable.intrinsicWidth.coerceAtLeast(1),
-                drawable.intrinsicHeight.coerceAtLeast(1),
-                Bitmap.Config.ARGB_8888
-            )
+            val bmp =
+                createBitmap(
+                    drawable.intrinsicWidth.coerceAtLeast(1),
+                    drawable.intrinsicHeight.coerceAtLeast(1)
+                )
             val canvas = Canvas(bmp)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -1,8 +1,9 @@
 package sgnv.anubis.app.ui.screens
 
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.Canvas
+import androidx.core.net.toUri
+import androidx.core.graphics.createBitmap
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -222,9 +223,9 @@ fun HomeScreen(
                     Row(Modifier.padding(top = 8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         if (shizukuStatus == ShizukuStatus.UNAVAILABLE) {
                             Button(onClick = {
-                                context.startActivity(android.content.Intent(
-                                    android.content.Intent.ACTION_VIEW,
-                                    android.net.Uri.parse("https://shizuku.rikka.app/download/")
+                                context.startActivity(Intent(
+                                    Intent.ACTION_VIEW,
+                                    "https://shizuku.rikka.app/download/".toUri()
                                 ))
                             }) { Text("Скачать") }
                         }
@@ -390,10 +391,7 @@ fun HomeScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    context.startActivity(android.content.Intent(
-                        android.content.Intent.ACTION_VIEW,
-                        android.net.Uri.parse(url)
-                    ))
+                    context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
                     viewModel.dismissDangerousAppWarning()
                 }) { Text("Подробнее") }
             },
@@ -424,11 +422,9 @@ fun HomeScreen(
         val iconBitmap = remember(pkg) {
             try {
                 val drawable = pm.getApplicationIcon(pkg)
-                val bmp = Bitmap.createBitmap(
+                val bmp = createBitmap(
                     drawable.intrinsicWidth.coerceAtLeast(1),
-                    drawable.intrinsicHeight.coerceAtLeast(1),
-                    Bitmap.Config.ARGB_8888
-                )
+                    drawable.intrinsicHeight.coerceAtLeast(1))
                 val canvas = Canvas(bmp)
                 drawable.setBounds(0, 0, canvas.width, canvas.height)
                 drawable.draw(canvas)
@@ -583,10 +579,9 @@ private fun AppIconItem(
     val iconBitmap = remember(packageName) {
         try {
             val drawable = pm.getApplicationIcon(packageName)
-            val bmp = Bitmap.createBitmap(
+            val bmp = createBitmap(
                 drawable.intrinsicWidth.coerceAtLeast(1),
-                drawable.intrinsicHeight.coerceAtLeast(1),
-                Bitmap.Config.ARGB_8888
+                drawable.intrinsicHeight.coerceAtLeast(1)
             )
             val canvas = Canvas(bmp)
             drawable.setBounds(0, 0, canvas.width, canvas.height)

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
@@ -1,6 +1,5 @@
 package sgnv.anubis.app.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.ui.MainViewModel
 
@@ -223,7 +224,7 @@ fun SettingsScreen(
                 TextButton(onClick = {
                     val intent = android.content.Intent(
                         android.content.Intent.ACTION_VIEW,
-                        android.net.Uri.parse("https://github.com/sogonov/anubis")
+                        "https://github.com/sogonov/anubis".toUri()
                     )
                     context.startActivity(intent)
                 }) {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
@@ -1,6 +1,6 @@
 package sgnv.anubis.app.ui.screens
 
-import android.graphics.Bitmap
+import androidx.core.graphics.createBitmap
 import android.graphics.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -266,10 +266,9 @@ fun VpnClientScreen(
                 val iconBitmap = remember(app.packageName) {
                     try {
                         val drawable = pm.getApplicationIcon(app.packageName)
-                        val bmp = Bitmap.createBitmap(
+                        val bmp = createBitmap(
                             drawable.intrinsicWidth.coerceAtLeast(1),
-                            drawable.intrinsicHeight.coerceAtLeast(1),
-                            Bitmap.Config.ARGB_8888
+                            drawable.intrinsicHeight.coerceAtLeast(1)
                         )
                         val canvas = Canvas(bmp)
                         drawable.setBounds(0, 0, canvas.width, canvas.height)

--- a/app/src/main/java/sgnv/anubis/app/update/UpdateChecker.kt
+++ b/app/src/main/java/sgnv/anubis/app/update/UpdateChecker.kt
@@ -1,6 +1,7 @@
 package sgnv.anubis.app.update
 
 import android.content.Context
+import androidx.core.content.edit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -29,12 +30,12 @@ object UpdateChecker {
 
     fun setEnabled(context: Context, enabled: Boolean) {
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putBoolean(KEY_ENABLED, enabled).apply()
+            .edit {putBoolean(KEY_ENABLED, enabled)}
     }
 
     fun skipVersion(context: Context, version: String) {
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
-            .edit().putString(KEY_SKIPPED_VERSION, version).apply()
+            .edit { putString(KEY_SKIPPED_VERSION, version)}
     }
 
     private fun skippedVersion(context: Context): String? =
@@ -87,7 +88,7 @@ object UpdateChecker {
                 found
             }
 
-            prefs.edit().putLong(KEY_LAST_CHECK_MS, now).apply()
+            prefs.edit { putLong(KEY_LAST_CHECK_MS, now) }
 
             UpdateInfo(
                 latestVersion = tagName,

--- a/app/src/main/java/sgnv/anubis/app/update/UpdateDialog.kt
+++ b/app/src/main/java/sgnv/anubis/app/update/UpdateDialog.kt
@@ -1,7 +1,7 @@
 package sgnv.anubis.app.update
 
 import android.content.Intent
-import android.net.Uri
+import androidx.core.net.toUri
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -46,7 +46,7 @@ fun UpdateDialog(
         confirmButton = {
             TextButton(onClick = {
                 val url = info.apkUrl ?: info.releaseUrl
-                context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                context.startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
                 onDismiss()
             }) { Text(if (info.apkUrl != null) "Скачать APK" else "Открыть релиз") }
         },


### PR DESCRIPTION
#82 
## Что сделано
- Код приведён к более единообразному KTX-стилю.
- Удалены лишние импорты.

## Как протестировано
- Проверена локальная сборка проекта.
- Приложение установлено и запущено на устройстве.
- Базовые пользовательские сценарии в затронутых экранах проверены вручную: регрессий по поведению не обнаружено.

## Важно
- Изменения носят технический характер и не нацелены на изменение бизнес-логики.