### PR TITLE
Fix dialog and bottom-sheet dismiss state handling

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
@@ -29,9 +29,9 @@ class StealthWidgetProvider : AppWidgetProvider() {
     companion object {
         const val ACTION_TOGGLE = "sgnv.anubis.app.WIDGET_TOGGLE"
 
-        val COLOR_ACTIVE = 0xFF4CAF50.toInt()
-        val COLOR_INACTIVE = 0xFF9E9E9E.toInt()
-        val COLOR_WORKING = 0xFFFFAA00.toInt()
+        const val COLOR_ACTIVE = 0xFF4CAF50.toInt()
+        const val COLOR_INACTIVE = 0xFF9E9E9E.toInt()
+        const val COLOR_WORKING = 0xFFFFAA00.toInt()
 
         fun updateAllWidgets(context: Context) {
             val vpnActive = isVpnActive(context)

--- a/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
@@ -276,7 +276,6 @@ class ShizukuManager(private val packageManager: PackageManager) {
                 Int::class.java,
                 String::class.java
             ).invoke(pm, packageName, newState, 0, currentUserId, CALLER_PACKAGE)
-            Unit
         }
 
     private fun forceStopInternal(packageName: String): Result<Unit> = runCatching {
@@ -284,7 +283,6 @@ class ShizukuManager(private val packageManager: PackageManager) {
         HiddenApiBypass.invoke(
             am::class.java, am, "forceStopPackage", packageName, currentUserId
         )
-        Unit
     }
 
     companion object {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
@@ -66,8 +66,10 @@ fun AddAppSheet(
     var query by rememberSaveable { mutableStateOf("") }
     var selectedPackages by rememberSaveable { mutableStateOf(setOf<String>()) }
     var isApplying by remember { mutableStateOf(false) }
-    var pendingNeverRestrict by remember { mutableStateOf<List<String>?>(null) }
     val normalizedQuery = query.trim()
+
+    var pendingNeverRestrict by remember { mutableStateOf<List<String>?>(null) }
+    val dismissNeverRestrictDialog: () -> Unit = { pendingNeverRestrict = null }
 
     val applySelection: () -> Unit = {
         val packagesToAssign = selectedPackages.toList()
@@ -246,7 +248,7 @@ fun AddAppSheet(
 
     pendingNeverRestrict?.let { offenders ->
         AlertDialog(
-            onDismissRequest = { pendingNeverRestrict = null },
+            onDismissRequest = dismissNeverRestrictDialog,
             title = { Text("Критичные приложения в выборе") },
             text = {
                 Column {
@@ -263,12 +265,12 @@ fun AddAppSheet(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    pendingNeverRestrict = null
+                    dismissNeverRestrictDialog()
                     applySelection()
                 }) { Text("Всё равно добавить") }
             },
             dismissButton = {
-                TextButton(onClick = { pendingNeverRestrict = null }) {
+                TextButton(onClick = dismissNeverRestrictDialog) {
                     Text("Отмена")
                 }
             }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
@@ -83,15 +83,17 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     val allApps by viewModel.installedApps.collectAsState()
     val context = LocalContext.current
     val prefs = remember { context.getSharedPreferences("settings", Context.MODE_PRIVATE) }
-    var showAutoWarning by remember { mutableStateOf(false) }
-    var pendingFirstAdd by remember { mutableStateOf<String?>(null) }
-
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     var searchActive by rememberSaveable { mutableStateOf(false) }
     var searchQuery by rememberSaveable { mutableStateOf("") }
-    var sortOrdinal by rememberSaveable { mutableIntStateOf(SortBy.PACKAGE.ordinal) }
+    var sortBy by rememberSaveable { mutableStateOf(SortBy.PACKAGE) }
     var sortMenuOpen by remember { mutableStateOf(false) }
-    val sortBy = SortBy.entries[sortOrdinal]
+
+    var showAutoWarning by remember { mutableStateOf(false) }
+    val dismissAutoWarning: () -> Unit = { showAutoWarning = false }
+
+    var pendingFirstAdd by remember { mutableStateOf<String?>(null) }
+    val dismissFirstAddDialog: () -> Unit = { pendingFirstAdd = null }
 
     val focusRequester = remember { FocusRequester() }
 
@@ -190,7 +192,7 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                             DropdownMenuItem(
                                 text = { Text(option.label) },
                                 onClick = {
-                                    sortOrdinal = option.ordinal
+                                    sortBy = option
                                     sortMenuOpen = false
                                 }
                             )
@@ -305,7 +307,7 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
 
     pendingFirstAdd?.let { pkg ->
         AlertDialog(
-            onDismissRequest = { pendingFirstAdd = null },
+            onDismissRequest = dismissFirstAddDialog,
             title = { Text("Добавить в группу?") },
             text = {
                 Text(
@@ -318,18 +320,18 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 TextButton(onClick = {
                     prefs.edit { putBoolean("seen_first_add_warning", true) }
                     viewModel.cycleAppGroup(pkg)
-                    pendingFirstAdd = null
+                    dismissFirstAddDialog()
                 }) { Text("Добавить") }
             },
             dismissButton = {
-                TextButton(onClick = { pendingFirstAdd = null }) { Text("Отмена") }
+                TextButton(onClick = dismissFirstAddDialog) { Text("Отмена") }
             }
         )
     }
 
     if (showAutoWarning) {
         AlertDialog(
-            onDismissRequest = { showAutoWarning = false },
+            onDismissRequest = dismissAutoWarning,
             title = { Text("Перед заморозкой") },
             text = {
                 Text(
@@ -343,12 +345,12 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
             confirmButton = {
                 TextButton(onClick = {
                     prefs.edit { putBoolean("seen_auto_warning", true)}
-                    showAutoWarning = false
+                    dismissAutoWarning()
                     viewModel.autoSelectRestricted()
                 }) { Text("Заморозить") }
             },
             dismissButton = {
-                TextButton(onClick = { showAutoWarning = false }) { Text("Отмена") }
+                TextButton(onClick = dismissAutoWarning) { Text("Отмена") }
             }
         )
     }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.ManagedApp
 import sgnv.anubis.app.service.StealthState
 import sgnv.anubis.app.shizuku.SHIZUKU_PACKAGE
@@ -110,8 +111,11 @@ fun HomeScreen(
 
     // Context menu state
     var menuApp by remember { mutableStateOf<String?>(null) }
+    val dismissMenuSheet: () -> Unit = { menuApp = null }
+
     // Inline "add to group" sheet: non-null means that group's sheet is open.
-    var addingToGroup by remember { mutableStateOf<sgnv.anubis.app.data.model.AppGroup?>(null) }
+    var addingToGroup by remember { mutableStateOf<AppGroup?>(null) }
+    val dismissAddSheet: () -> Unit = { addingToGroup = null }
 
     // Ephemeral benchmark message. Conflate-style: each new emit overwrites the previous
     // and resets the 3s hide timer. Avoids flicker if multiple emits arrive in a burst
@@ -241,7 +245,7 @@ fun HomeScreen(
                                 if (launch != null) context.startActivity(launch)
                             }) { Text("Открыть Shizuku") }
                             ShizukuStatus.NO_PERMISSION -> Button(onClick = { viewModel.requestShizukuPermission() }) { Text("Разрешить") }
-                            ShizukuStatus.READY -> Unit
+                            ShizukuStatus.READY -> Unit // unreachable
                         }
                     }
                 }
@@ -260,7 +264,7 @@ fun HomeScreen(
                 frozenVersion = frozenVersion,
                 onClick = { pkg -> viewModel.launchLocal(pkg) },
                 onLongClick = { pkg -> menuApp = pkg },
-                onAdd = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LOCAL_AUTO_UNFREEZE }
+                onAdd = { addingToGroup = AppGroup.LOCAL_AUTO_UNFREEZE }
             )
         }
 
@@ -275,7 +279,7 @@ fun HomeScreen(
                 frozenVersion = frozenVersion,
                 onClick = { pkg -> viewModel.launchLocal(pkg) },
                 onLongClick = { pkg -> menuApp = pkg },
-                onAdd = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LOCAL }
+                onAdd = { addingToGroup = AppGroup.LOCAL }
             )
         }
 
@@ -290,7 +294,7 @@ fun HomeScreen(
                 frozenVersion = frozenVersion,
                 onClick = { pkg -> viewModel.launchWithVpn(pkg) },
                 onLongClick = { pkg -> menuApp = pkg },
-                onAdd = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LAUNCH_VPN }
+                onAdd = { addingToGroup = AppGroup.LAUNCH_VPN }
             )
         }
 
@@ -305,7 +309,7 @@ fun HomeScreen(
                 frozenVersion = frozenVersion,
                 onClick = { pkg -> viewModel.launchWithVpn(pkg) },
                 onLongClick = { pkg -> menuApp = pkg },
-                onAdd = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.VPN_ONLY }
+                onAdd = { addingToGroup = AppGroup.VPN_ONLY }
             )
         }
 
@@ -323,22 +327,22 @@ fun HomeScreen(
                 EmptyGroupAddButton(
                     label = "Без VPN + уведомления",
                     tint = MaterialTheme.colorScheme.secondary,
-                    onClick = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LOCAL_AUTO_UNFREEZE }
+                    onClick = { addingToGroup = AppGroup.LOCAL_AUTO_UNFREEZE }
                 )
                 EmptyGroupAddButton(
                     label = "Без VPN",
                     tint = MaterialTheme.colorScheme.error,
-                    onClick = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LOCAL }
+                    onClick = { addingToGroup = AppGroup.LOCAL }
                 )
                 EmptyGroupAddButton(
                     label = "Запуск с VPN",
                     tint = MaterialTheme.colorScheme.primary,
-                    onClick = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.LAUNCH_VPN }
+                    onClick = { addingToGroup = AppGroup.LAUNCH_VPN }
                 )
                 EmptyGroupAddButton(
                     label = "Только VPN",
                     tint = MaterialTheme.colorScheme.tertiary,
-                    onClick = { addingToGroup = sgnv.anubis.app.data.model.AppGroup.VPN_ONLY }
+                    onClick = { addingToGroup = AppGroup.VPN_ONLY }
                 )
             }
         }
@@ -446,7 +450,7 @@ fun HomeScreen(
         AddAppSheet(
             viewModel = viewModel,
             targetGroup = group,
-            onDismiss = { addingToGroup = null }
+            onDismiss = dismissAddSheet
         )
     }
 
@@ -473,7 +477,7 @@ fun HomeScreen(
         }
 
         ModalBottomSheet(
-            onDismissRequest = { menuApp = null },
+            onDismissRequest = dismissMenuSheet,
             sheetState = rememberModalBottomSheetState()
         ) {
             Column(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)) {
@@ -505,14 +509,14 @@ fun HomeScreen(
                 // Actions
                 BottomSheetAction(
                     text = if (isFrozen) "Разморозить" else "Заморозить",
-                    onClick = { viewModel.requestToggleAppFrozen(pkg); menuApp = null }
+                    onClick = { viewModel.requestToggleAppFrozen(pkg); dismissMenuSheet() }
                 )
 
                 BottomSheetAction(
                     text = "Создать ярлык на рабочий стол",
                     onClick = {
                         viewModel.createShortcut(pkg)
-                        menuApp = null
+                        dismissMenuSheet()
                     }
                 )
 
@@ -520,7 +524,7 @@ fun HomeScreen(
                     text = "Убрать из группы",
                     onClick = {
                         viewModel.removeFromGroup(pkg)
-                        menuApp = null
+                        dismissMenuSheet()
                     }
                 )
 

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
@@ -37,9 +37,13 @@ fun RecoveryScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var showResetDialog by remember { mutableStateOf(false) }
-    var showScanDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
+
+    var showResetDialog by remember { mutableStateOf(false) }
+    val dismissResetDialog: () -> Unit = { showResetDialog = false }
+
+    var showScanDialog by remember { mutableStateOf(false) }
+    val dismissScanDialog: () -> Unit = { showScanDialog = false }
 
     LaunchedEffect(Unit) {
         viewModel.resetCompleted.collect { count ->
@@ -152,7 +156,7 @@ fun RecoveryScreen(
 
     if (showResetDialog) {
         AlertDialog(
-            onDismissRequest = { showResetDialog = false },
+            onDismissRequest = dismissResetDialog,
             title = { Text("Сбросить Anubis?") },
             text = {
                 Text(
@@ -163,20 +167,20 @@ fun RecoveryScreen(
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.unfreezeAllAndClear()
-                    showResetDialog = false
+                    dismissResetDialog()
                 }) {
                     Text("Сбросить", color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showResetDialog = false }) { Text("Отмена") }
+                TextButton(onClick = dismissResetDialog) { Text("Отмена") }
             }
         )
     }
 
     if (showScanDialog) {
         AlertDialog(
-            onDismissRequest = { showScanDialog = false },
+            onDismissRequest = dismissScanDialog,
             title = { Text("Разморозить все отключённые?") },
             text = {
                 Text(
@@ -188,13 +192,13 @@ fun RecoveryScreen(
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.unfreezeAllUserDisabled()
-                    showScanDialog = false
+                    dismissScanDialog()
                 }) {
                     Text("Разморозить всё", color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showScanDialog = false }) { Text("Отмена") }
+                TextButton(onClick = dismissScanDialog) { Text("Отмена") }
             }
         )
     }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -142,7 +142,7 @@ fun SettingsScreen(
                                 ShizukuStatus.NOT_INSTALLED -> "Нажмите, чтобы скачать"
                                 ShizukuStatus.NOT_RUNNING -> "Нажмите, чтобы открыть Shizuku"
                                 ShizukuStatus.NO_PERMISSION -> "Нажмите, чтобы выдать разрешение"
-                                ShizukuStatus.READY -> ""
+                                ShizukuStatus.READY -> "" // unreachable
                             },
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
#89 

## Что сделано
- Логика закрытия оверлеев приведена к единому виду через `dismiss*()` обработчики. Lint больше не ругается на "assigned value is never read"
- Небольшие косметические правки затронутых классов

## Как протестировано
- Сборка: `./gradlew :app:compileDebugKotlin`
- Ручная проверка всех оверлеев, кнопок на них.

## Важно
- Изменения сфокусированы на корректном управлении состоянием UI (dismiss/reset state) и не меняют бизнес-логику операций.