### PR TITLE
Add launcher safe mode to reduce duplicate home screen shortcuts

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -62,7 +62,10 @@ class StealthOrchestrator(
         // If VPN is on, we're in stealth mode (spies should be frozen)
         // If VPN is off, stealth is disabled
         val newState = if (vpnActive) StealthState.ENABLED else StealthState.DISABLED
-        if (_state.value != StealthState.ENABLING && _state.value != StealthState.DISABLING) {
+        if (_state.value != StealthState.ENABLING
+            && _state.value != StealthState.DISABLING
+            && _state.value != StealthState.UNFREEZING
+        ) {
             _state.value = newState
         }
     }
@@ -200,6 +203,7 @@ class StealthOrchestrator(
         }
 
         _progressText.value = "Размораживаю..."
+        _state.value = StealthState.UNFREEZING
         // After confirmed VPN shutdown, align managed groups with the new network state.
         applyManagedStateForVpn(active = false)
         _progressText.value = null
@@ -207,7 +211,10 @@ class StealthOrchestrator(
 
     private fun alignStateWithVpn() {
         val current = _state.value
-        if (current == StealthState.ENABLING || current == StealthState.DISABLING) {
+        if (current == StealthState.ENABLING
+            || current == StealthState.DISABLING
+            || current == StealthState.UNFREEZING
+        ) {
             _state.value = if (vpnClientManager.vpnActive.value) {
                 StealthState.ENABLED
             } else {
@@ -345,7 +352,22 @@ class StealthOrchestrator(
     }
 
     private suspend fun unfreezeGroup(group: AppGroup): Int {
-        val packages = repository.getPackagesByGroup(group)
+        val packages = repository.getPackagesByGroup(group).toList()
+        if (AppSettings.shouldUseLauncherSafeMode(context)) {
+            var transitioned = 0
+            packages.forEachIndexed { index, pkg ->
+                if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
+                    shizukuManager.unfreezeApp(pkg)
+                    transitioned++
+                }
+                // On MIUI/HyperOS and some OEM launchers, bursts of package-enabled events
+                // are handled as repeated "new app" inserts and produce duplicate icons.
+                if (index < packages.lastIndex) {
+                    delay(LAUNCHER_SAFE_UNFREEZE_DELAY_MS)
+                }
+            }
+            return transitioned
+        }
         val sem = Semaphore(FREEZE_CONCURRENCY)
         val counter = AtomicInteger(0)
         coroutineScope {
@@ -465,6 +487,9 @@ class StealthOrchestrator(
         // force-stop. If we hit this ceiling something is genuinely broken (Shizuku
         // wedged, VPN client unresponsive) — no point waiting longer.
         const val TOTAL_OP_TIMEOUT_MS = 45_000L
+
+        // Launcher-safe profile: serialize mass-unfreeze to avoid duplicate launcher icons.
+        const val LAUNCHER_SAFE_UNFREEZE_DELAY_MS = 180L
     }
 }
 
@@ -472,7 +497,8 @@ enum class StealthState {
     DISABLED,
     ENABLING,
     ENABLED,
-    DISABLING
+    DISABLING,
+    UNFREEZING
 }
 
 

--- a/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
+++ b/app/src/main/java/sgnv/anubis/app/settings/AppSettings.kt
@@ -2,11 +2,13 @@ package sgnv.anubis.app.settings
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientType
+import androidx.core.content.edit
 
 /** Centralized SharedPreferences keys for app-level settings. */
 object AppSettings {
@@ -16,8 +18,15 @@ object AppSettings {
     const val KEY_BACKGROUND_MONITORING = "background_monitoring"
     const val KEY_FREEZE_ON_BOOT = "freeze_on_boot"
     const val KEY_UNFREEZE_ON_VPN_TOGGLE = "unfreeze_on_vpn_toggle"
+    const val KEY_LAUNCHER_SAFE_MODE = "launcher_safe_mode"
     private const val KEY_VPN_CLIENT_AUTOMATION_TOKEN_PREFIX = "vpn_client_automation_token_"
     private const val TAG = "AppSettings"
+
+    private val LAUNCHER_SAFE_MODE_OEM_HINTS = listOf(
+        "xiaomi",
+        "redmi",
+        "poco",
+    )
 
     @Volatile
     private var securePrefsCache: SharedPreferences? = null
@@ -58,14 +67,30 @@ object AppSettings {
 
         val legacyPrefs = prefs(context)
         val legacyToken = legacyPrefs.getString(key, null)?.takeIf { it.isNotBlank() } ?: return null
-        securePrefs.edit().putString(key, legacyToken).apply()
-        legacyPrefs.edit().remove(key).apply()
+        securePrefs.edit { putString(key, legacyToken) }
+        legacyPrefs.edit { remove(key) }
         return legacyToken
     }
 
     /** Optional behavior: unfreeze the opposite managed group after VPN state changes. */
     fun shouldUnfreezeManagedAppsOnVpnToggle(context: Context): Boolean {
         return prefs(context).getBoolean(KEY_UNFREEZE_ON_VPN_TOGGLE, false)
+    }
+
+    /**
+     * Slow down mass-unfreeze to reduce launcher duplicate shortcuts.
+     * Enabled by default on Xiaomi/Redmi/POCO where the issue is frequent.
+     */
+    fun shouldUseLauncherSafeMode(context: Context): Boolean {
+        return prefs(context).getBoolean(KEY_LAUNCHER_SAFE_MODE, launcherSafeModeDefault())
+    }
+
+    private fun launcherSafeModeDefault(): Boolean {
+        val brand = Build.BRAND.orEmpty().lowercase()
+        val manufacturer = Build.MANUFACTURER.orEmpty().lowercase()
+        return LAUNCHER_SAFE_MODE_OEM_HINTS.any { hint ->
+            brand.contains(hint) || manufacturer.contains(hint)
+        }
     }
 
     fun getVpnClientAutomationToken(context: Context, packageName: String): String? {
@@ -85,7 +110,7 @@ object AppSettings {
             editor.putString(key, token)
         }
         editor.apply()
-        prefs(context).edit().remove(key).apply()
+        prefs(context).edit { remove(key) }
     }
 
     fun loadSelectedVpnClient(

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -94,6 +94,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // Exposes issue #31 behavior to Compose settings UI.
     private val _unfreezeManagedAppsOnVpnToggle = MutableStateFlow(false)
     val unfreezeManagedAppsOnVpnToggle: StateFlow<Boolean> = _unfreezeManagedAppsOnVpnToggle
+    
+    private val _launcherSafeMode = MutableStateFlow(false)
+    val launcherSafeMode: StateFlow<Boolean> = _launcherSafeMode
 
     private val _dangerousAppWarning = MutableStateFlow<String?>(null)
     val dangerousAppWarning: StateFlow<String?> = _dangerousAppWarning
@@ -124,6 +127,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         observeVpnState()
         loadBackgroundMonitoring()
         loadUnfreezeManagedAppsOnVpnToggle()
+        loadLauncherSafeMode()
         checkDangerousApps()
         loadUpdateCheckPref()
         autoCheckForUpdates()
@@ -471,6 +475,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         // Load once on startup; services read the same flag directly from shared prefs.
         _unfreezeManagedAppsOnVpnToggle.value = AppSettings.prefs(getApplication())
             .getBoolean(AppSettings.KEY_UNFREEZE_ON_VPN_TOGGLE, false)
+    }
+
+    fun setLauncherSafeMode(enabled: Boolean) {
+        _launcherSafeMode.value = enabled
+        AppSettings.prefs(getApplication())
+            .edit {
+                putBoolean(AppSettings.KEY_LAUNCHER_SAFE_MODE, enabled)
+            }
+    }
+
+    private fun loadLauncherSafeMode() {
+        _launcherSafeMode.value = AppSettings.shouldUseLauncherSafeMode(getApplication())
     }
 
     fun dismissDangerousAppWarning() {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -55,10 +55,12 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import sgnv.anubis.app.R
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.ManagedApp
 import sgnv.anubis.app.service.StealthState
@@ -98,12 +100,14 @@ fun HomeScreen(
     val manualUnfreezeWarning by viewModel.manualUnfreezeWarning.collectAsState()
 
     val isEnabled = stealthState == StealthState.ENABLED
-    val isTransitioning = stealthState == StealthState.ENABLING || stealthState == StealthState.DISABLING
+    val isTransitioning = stealthState == StealthState.ENABLING
+        || stealthState == StealthState.DISABLING
+        || stealthState == StealthState.UNFREEZING
 
     val statusColor by animateColorAsState(
         when (stealthState) {
             StealthState.ENABLED -> Color(0xFF2E7D32)
-            StealthState.ENABLING, StealthState.DISABLING -> Color(0xFFF57F17)
+            StealthState.ENABLING, StealthState.DISABLING, StealthState.UNFREEZING -> Color(0xFFF57F17)
             StealthState.DISABLED -> MaterialTheme.colorScheme.surfaceVariant
         },
         label = "statusColor"
@@ -152,10 +156,11 @@ fun HomeScreen(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         when (stealthState) {
-                            StealthState.ENABLED -> "ЗАЩИТА АКТИВНА"
-                            StealthState.ENABLING -> "ВКЛЮЧЕНИЕ..."
-                            StealthState.DISABLING -> "ОТКЛЮЧЕНИЕ..."
-                            StealthState.DISABLED -> "ЗАЩИТА ОТКЛЮЧЕНА"
+                            StealthState.ENABLED -> stringResource(R.string.home_status_enabled)
+                            StealthState.ENABLING -> stringResource(R.string.home_status_enabling)
+                            StealthState.DISABLING -> stringResource(R.string.home_status_disabling)
+                            StealthState.UNFREEZING -> stringResource(R.string.home_status_unfreezing)
+                            StealthState.DISABLED -> stringResource(R.string.home_status_disabled)
                         },
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -22,9 +22,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import sgnv.anubis.app.R
 import sgnv.anubis.app.shizuku.SHIZUKU_PACKAGE
 import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.ui.MainViewModel
@@ -37,6 +39,7 @@ fun SettingsScreen(
 ) {
     val shizukuStatus by viewModel.shizukuStatus.collectAsState()
     val unfreezeManagedAppsOnVpnToggle by viewModel.unfreezeManagedAppsOnVpnToggle.collectAsState()
+    val launcherSafeMode by viewModel.launcherSafeMode.collectAsState()
 
     Column(
         modifier = modifier
@@ -110,6 +113,32 @@ fun SettingsScreen(
                 androidx.compose.material3.Switch(
                     checked = unfreezeManagedAppsOnVpnToggle,
                     onCheckedChange = { viewModel.setUnfreezeManagedAppsOnVpnToggle(it) }
+                )
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.settings_launcher_safe_mode_title),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        stringResource(R.string.settings_launcher_safe_mode_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                androidx.compose.material3.Switch(
+                    checked = launcherSafeMode,
+                    onCheckedChange = { viewModel.setLauncherSafeMode(it) }
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Anubis</string>
     <string name="tile_label">Anubis</string>
+
+    <string name="home_status_enabled">ЗАЩИТА АКТИВНА</string>
+    <string name="home_status_enabling">ВКЛЮЧЕНИЕ...</string>
+    <string name="home_status_disabling">ОТКЛЮЧЕНИЕ...</string>
+    <string name="home_status_unfreezing">РАЗМОРОЗКА...</string>
+    <string name="home_status_disabled">ЗАЩИТА ОТКЛЮЧЕНА</string>
+
+    <string name="settings_launcher_safe_mode_title">Безопасный режим лаунчера</string>
+    <string name="settings_launcher_safe_mode_description">Уменьшает вероятность дубликатов ярлыков: массовая разморозка выполняется по одному приложению с короткой паузой.</string>
 </resources>


### PR DESCRIPTION
Решение для #98 

## Что сделано

Решение проблемы накопления дубликатов ярлыков в лаунчере (особенно MIUI/HyperOS) при циклах freeze/unfreeze.

### Основные изменения

**Настройки**
- Добавлен флаг `Launcher Safe Mode` (по умолчанию включен для OEM из списка: xiaomi/redmi/poco)
- UI-переключатель на экране настроек.

**Другое**
- Изменена стратегия массовой разморозки: при включенном `Launcher Safe Mode` разморозка выполняется последовательно: добавлена короткая пауза между приложениями. (У меня 63 приложения размораживаются за 11.8с.)
- Улучшен статус в верхней панели Home: добавлен отдельный статус при котором показывается `РАЗМОРОЗКА...`
- Строки статусов вынесены в `strings.xml`:

## Ручная проверка:
  1. Включить `Безопасный режим лаунчера` в настройках.
  2. Несколько раз выполнить цикл ON/OFF.
  3. Убедиться, что в верхней панели показывается `РАЗМОРОЗКА...`.
  4. Проверить, что дубликаты ярлыков появляются заметно реже.