### PR TITLE
Extend non-freezable app protection list

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/data/NeverRestrictApps.kt
+++ b/app/src/main/java/sgnv/anubis/app/data/NeverRestrictApps.kt
@@ -5,11 +5,9 @@ package sgnv.anubis.app.data
  * phone calls, or 2FA flows — which typically requires a factory reset or ADB
  * recovery for non-technical users.
  *
- * Enforced in two places:
- *  - [sgnv.anubis.app.data.repository.AppRepository.autoSelectRestricted] filters
- *    these out so Auto-Select never proposes them.
- *  - [sgnv.anubis.app.ui.screens.AddAppSheet] shows a confirmation dialog before
- *    assigning any of these to a group via manual multi-select.
+ * This list is one input to [sgnv.anubis.app.policy.FreezeSafetyPolicy].
+ * The policy layer also adds VPN client packages and is the single entry point
+ * used by UI warnings and auto-selection filters.
  *
  * List curated from incidents in the issue tracker and Habr feedback
  * (Yandex.Клавиатура auto-selected by the `ru.yandex.` prefix heuristic in
@@ -18,6 +16,9 @@ package sgnv.anubis.app.data
 object NeverRestrictApps {
 
     val packageNames = setOf(
+        // Anubis itself - never allow self-freeze
+        "sgnv.anubis.app",
+
         // Keyboards — without them text input stops working
         "com.google.android.inputmethod.latin",       // Gboard
         "com.samsung.android.honeyboard",             // Samsung Keyboard

--- a/app/src/main/java/sgnv/anubis/app/data/repository/AppRepository.kt
+++ b/app/src/main/java/sgnv/anubis/app/data/repository/AppRepository.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import sgnv.anubis.app.data.DefaultRestrictedApps
-import sgnv.anubis.app.data.NeverRestrictApps
 import sgnv.anubis.app.data.db.ManagedAppDao
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.InstalledAppInfo
 import sgnv.anubis.app.data.model.ManagedApp
+import sgnv.anubis.app.policy.FreezeSafetyPolicy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -52,7 +52,7 @@ class AppRepository(
         val installed = getInstalledPackageNames()
         val toSelect = installed
             .filter { DefaultRestrictedApps.isKnownRestricted(it) }
-            .filter { !NeverRestrictApps.isNeverRestrict(it) }
+            .filter { !FreezeSafetyPolicy.isProtected(it) }
             .map { ManagedApp(it, AppGroup.LOCAL) }
         dao.insertAll(toSelect)
         return toSelect.size

--- a/app/src/main/java/sgnv/anubis/app/policy/FreezeSafetyPolicy.kt
+++ b/app/src/main/java/sgnv/anubis/app/policy/FreezeSafetyPolicy.kt
@@ -1,0 +1,21 @@
+package sgnv.anubis.app.policy
+
+import sgnv.anubis.app.data.NeverRestrictApps
+import sgnv.anubis.app.vpn.VpnClientType
+
+/**
+ * Single source of truth for "do not freeze blindly" rules.
+ */
+object FreezeSafetyPolicy {
+
+    private val vpnClientPackages: Set<String> = VpnClientType.entries
+        .mapTo(mutableSetOf()) { it.packageName }
+
+    fun isProtected(packageName: String): Boolean =
+        NeverRestrictApps.isNeverRestrict(packageName) || packageName in vpnClientPackages
+
+    fun findProtected(packageNames: Collection<String>): List<String> =
+        packageNames
+            .distinct()
+            .filter { pkg -> isProtected(pkg) }
+}

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
@@ -38,11 +38,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
-import sgnv.anubis.app.data.NeverRestrictApps
+import sgnv.anubis.app.policy.FreezeSafetyPolicy
 import sgnv.anubis.app.data.model.AppGroup
+import sgnv.anubis.app.R
 import sgnv.anubis.app.ui.MainViewModel
 import androidx.core.graphics.createBitmap
 
@@ -76,11 +78,7 @@ fun AddAppSheet(
         scope.launch {
             isApplying = true
             viewModel.setAppsGroup(packagesToAssign, targetGroup)
-            Toast.makeText(
-                context,
-                "Добавлено ${packagesToAssign.size} приложений",
-                Toast.LENGTH_SHORT
-            ).show()
+            Toast.makeText(context, context.getString(R.string.add_app_sheet_added_count, packagesToAssign.size), Toast.LENGTH_SHORT).show()
             onDismiss()
         }
     }
@@ -229,7 +227,7 @@ fun AddAppSheet(
                 }
                 Button(
                     onClick = {
-                        val risky = selectedPackages.filter { NeverRestrictApps.isNeverRestrict(it) }
+                        val risky = FreezeSafetyPolicy.findProtected(selectedPackages)
                         if (risky.isNotEmpty()) {
                             pendingNeverRestrict = risky
                         } else {
@@ -249,12 +247,11 @@ fun AddAppSheet(
     pendingNeverRestrict?.let { offenders ->
         AlertDialog(
             onDismissRequest = dismissNeverRestrictDialog,
-            title = { Text("Критичные приложения в выборе") },
+            title = { Text(stringResource(R.string.add_app_sheet_critical_title)) },
             text = {
                 Column {
                     Text(
-                        "Эти приложения отвечают за ввод текста, звонки или 2FA. " +
-                            "Их заморозка может заблокировать устройство:",
+                        stringResource(R.string.add_app_sheet_critical_message),
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Spacer(Modifier.height(8.dp))
@@ -264,14 +261,38 @@ fun AddAppSheet(
                 }
             },
             confirmButton = {
-                TextButton(onClick = {
-                    dismissNeverRestrictDialog()
-                    applySelection()
-                }) { Text("Всё равно добавить") }
-            },
-            dismissButton = {
-                TextButton(onClick = dismissNeverRestrictDialog) {
-                    Text("Отмена")
+                Column(horizontalAlignment = Alignment.End) {
+                    TextButton(onClick = {
+                        val safePackages = selectedPackages.filterNot { it in offenders }
+                        dismissNeverRestrictDialog()
+                        if (safePackages.isEmpty()) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.add_app_sheet_no_safe_apps),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            return@TextButton
+                        }
+                        scope.launch {
+                            isApplying = true
+                            viewModel.setAppsGroup(safePackages, targetGroup)
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.add_app_sheet_added_count, safePackages.size),
+                                Toast.LENGTH_LONG
+                            ).show()
+                            onDismiss()
+                        }
+                    }) { Text(stringResource(R.string.add_app_sheet_add_safe)) }
+
+                    TextButton(onClick = {
+                        dismissNeverRestrictDialog()
+                        applySelection()
+                    }) { Text(stringResource(R.string.add_app_sheet_add_anyway)) }
+
+                    TextButton(onClick = dismissNeverRestrictDialog) {
+                        Text(stringResource(R.string.common_cancel))
+                    }
                 }
             }
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,13 @@
 <resources>
     <string name="app_name">Anubis</string>
     <string name="tile_label">Anubis</string>
+
+    <string name="add_app_sheet_critical_title">Критичные приложения в выборе</string>
+    <string name="add_app_sheet_critical_message">Эти приложения отвечают за ввод текста, звонки, 2FA или являются VPN-клиентами. Их заморозка может заблокировать устройство:</string>
+    <string name="add_app_sheet_added_count">Добавлено %1$d приложений</string>
+    <string name="add_app_sheet_no_safe_apps">Нет безопасных приложений для добавления</string>
+    <string name="add_app_sheet_add_safe">Добавить только безопасные</string>
+    <string name="add_app_sheet_add_anyway">Добавить все</string>
+
+    <string name="common_cancel">Отмена</string>
 </resources>


### PR DESCRIPTION
Решение #100 
### Что сделано

- Введена единая политика проверки защищённых приложений.
- В защищённый список теперь входят:
  - критичные приложения из `NeverRestrictApps`,
  - все поддерживаемые VPN-клиенты из `vpnClientPackages`,
  - само приложение Anubis.
  
- Обновлён диалог предупреждения о критичных приложениях: добавлена кнопка **«Добавить только безопасные»**.  
  Опасные для заморозки приложения исключаются из списка в процессе добавления в группу.
  
- Новый/изменённый UI-текст вынесен в `strings.xml`.

### Зачем это нужно

- Снижает риск критичных сценариев:
  - заморозка VPN-клиента,
  - самозаморозка приложения.
- Упрощает поддержку новых VPN-клиентов.
- Улучшает UX при массовом добавлении приложений в группы.

###  Ручная проверка диалога:
  1. Выбрать в списке хотя бы одно защищённое приложение (например, VPN-клиент).
  2. Нажать **«Готово»**.
  3. Убедиться, что открывается предупреждающий диалог со списком защищённых пакетов.
  4. Проверить сценарии кнопок:
     - **«Добавить только безопасные»** — в группу добавляются только незащищённые приложения;
     - **«Добавить все»** — добавляется весь выбранный список, включая защищённые;
     - **«Отмена»** — изменения не применяются.
