### PR TITLE
Remove deprecated allNetworks usage in VPN status consumers

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
@@ -1,10 +1,9 @@
 package sgnv.anubis.app.service
 
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import sgnv.anubis.app.AnubisApp
+import sgnv.anubis.app.R
 import sgnv.anubis.app.settings.AppSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -66,20 +65,13 @@ class StealthTileService : TileService() {
         val tile = qsTile ?: return
         val vpnActive = isActive ?: isVpnActive()
         tile.state = if (vpnActive) Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
-        tile.label = if (vpnActive) "Stealth ON" else "Stealth OFF"
+        tile.label = if (vpnActive) getString(R.string.stealth_status_on) else getString(R.string.stealth_status_off)
         tile.updateTile()
     }
 
     private fun isVpnActive(): Boolean {
-        val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
-        return try {
-            cm.allNetworks.any { network ->
-                cm.getNetworkCapabilities(network)
-                    ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
-            }
-        } catch (e: Exception) {
-            false
-        }
+        val app = application as AnubisApp
+        return app.vpnClientManager.vpnActive.value
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
@@ -6,9 +6,8 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.widget.RemoteViews
+import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
 
 class StealthWidgetProvider : AppWidgetProvider() {
@@ -37,7 +36,7 @@ class StealthWidgetProvider : AppWidgetProvider() {
             val vpnActive = isVpnActive(context)
             updateAllWidgets(
                 context,
-                if (vpnActive) "Stealth ON" else "Stealth OFF",
+                if (vpnActive) context.getString(R.string.stealth_status_on) else context.getString(R.string.stealth_status_off),
                 if (vpnActive) COLOR_ACTIVE else COLOR_INACTIVE
             )
         }
@@ -53,7 +52,7 @@ class StealthWidgetProvider : AppWidgetProvider() {
             val vpnActive = isVpnActive(context)
             manager.updateAppWidget(widgetId, buildViews(
                 context,
-                if (vpnActive) "Stealth ON" else "Stealth OFF",
+                if (vpnActive) context.getString(R.string.stealth_status_on) else context.getString(R.string.stealth_status_off),
                 if (vpnActive) COLOR_ACTIVE else COLOR_INACTIVE
             ))
         }
@@ -74,15 +73,8 @@ class StealthWidgetProvider : AppWidgetProvider() {
         }
 
         fun isVpnActive(context: Context): Boolean {
-            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            return try {
-                cm.allNetworks.any { network ->
-                    cm.getNetworkCapabilities(network)
-                        ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
-                }
-            } catch (e: Exception) {
-                false
-            }
+            val app = context.applicationContext as AnubisApp
+            return app.vpnClientManager.vpnActive.value
         }
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
 import sgnv.anubis.app.ui.MainActivity
+import java.util.Collections
 
 /**
  * Foreground service that syncs stealth state with real VPN state while the UI is
@@ -37,6 +38,7 @@ class VpnMonitorService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private val activeExternalVpnNetworks = Collections.synchronizedSet(mutableSetOf<Network>())
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
@@ -60,6 +62,7 @@ class VpnMonitorService : Service() {
 
         val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
         val app = applicationContext as AnubisApp
+        activeExternalVpnNetworks.clear()
 
         val request = NetworkRequest.Builder()
             .addTransportType(NetworkCapabilities.TRANSPORT_VPN)
@@ -72,6 +75,7 @@ class VpnMonitorService : Service() {
                 // would re-freeze groups that disable() just unfroze.
                 if (isOwnVpnNetwork(cm, network)) return
                 if (StealthVpnService.dummyVpnInFlight) return
+                activeExternalVpnNetworks.add(network)
                 scope.launch {
                     withTimeoutOrNull(APPLY_STATE_TIMEOUT_MS) {
                         app.orchestrator.freezeOnly()
@@ -83,15 +87,9 @@ class VpnMonitorService : Service() {
             override fun onLost(network: Network) {
                 if (isOwnVpnNetwork(cm, network)) return
                 if (StealthVpnService.dummyVpnInFlight) return
-                // Exclude the just-lost network: at the moment onLost is dispatched,
-                // the system may not have removed it from allNetworks yet. Without
-                // this, stillActive sees the dying network and we skip freezeVpnOnly
-                // — state gets stuck at ENABLED after external VPN crashes.
-                val stillActive = cm.allNetworks.any { n ->
-                    if (n == network) return@any false
-                    val caps = cm.getNetworkCapabilities(n) ?: return@any false
-                    caps.hasTransport(NetworkCapabilities.TRANSPORT_VPN) &&
-                        caps.ownerUid != Process.myUid()
+                activeExternalVpnNetworks.remove(network)
+                val stillActive = synchronized(activeExternalVpnNetworks) {
+                    activeExternalVpnNetworks.isNotEmpty()
                 }
                 if (!stillActive) {
                     scope.launch {
@@ -116,6 +114,7 @@ class VpnMonitorService : Service() {
     }
 
     private fun stopVpnMonitoring() {
+        activeExternalVpnNetworks.clear()
         networkCallback?.let {
             try {
                 val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -133,8 +132,8 @@ class VpnMonitorService : Service() {
         )
 
         return NotificationCompat.Builder(this, AnubisApp.CHANNEL_ID)
-            .setContentTitle("Anubis: мониторинг активен")
-            .setContentText("Автозаморозка при изменении VPN")
+            .setContentTitle(getString(R.string.vpn_monitor_notification_title))
+            .setContentText(getString(R.string.vpn_monitor_notification_text))
             .setSmallIcon(R.drawable.ic_shield)
             .setOngoing(true)
             .setContentIntent(openIntent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,9 @@
 <resources>
     <string name="app_name">Anubis</string>
     <string name="tile_label">Anubis</string>
+
+    <string name="stealth_status_on">Stealth ON</string>
+    <string name="stealth_status_off">Stealth OFF</string>
+    <string name="vpn_monitor_notification_title">Anubis: мониторинг активен</string>
+    <string name="vpn_monitor_notification_text">Автозаморозка при изменении VPN</string>
 </resources>


### PR DESCRIPTION
Для #107 

## Что сделано

- Убрано использование deprecated `ConnectivityManager.allNetworks` из:
  - StealthTileService
  - StealthWidgetProvider
  - VpnMonitorService
- Tile и виджет переведены на единый источник статуса VPN через `VpnClientManager`.
- В `VpnMonitorService` добавлен трекинг активных внешних VPN-сетей через внутренний набор сетей вместо опроса `allNetworks`.

## Зачем

- Снизить зависимость от deprecated API.
- Убрать дублирование логики определения VPN-статуса.
- Сделать поведение tile/виджета/монитора более консистентным.

## Ручная проверка:
Переключая статусы VPN в сабже и клиенте проверять:
  - Tile в шторке показывает актуальный статус VPN.
  - Виджет на рабочем столе показывает актуальный статус VPN.
  - `VpnMonitorService` корректно реагирует на `onAvailable/onLost` внешнего VPN.