### PR TITLE
Refactor app icon rendering and widget color resources

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetProvider.kt
@@ -29,16 +29,16 @@ class StealthWidgetProvider : AppWidgetProvider() {
     companion object {
         const val ACTION_TOGGLE = "sgnv.anubis.app.WIDGET_TOGGLE"
 
-        const val COLOR_ACTIVE = 0xFF4CAF50.toInt()
-        const val COLOR_INACTIVE = 0xFF9E9E9E.toInt()
-        const val COLOR_WORKING = 0xFFFFAA00.toInt()
+        fun activeColor(context: Context): Int = context.getColor(R.color.widget_icon_active)
+        fun inactiveColor(context: Context): Int = context.getColor(R.color.widget_icon_inactive)
+        fun workingColor(context: Context): Int = context.getColor(R.color.widget_icon_working)
 
         fun updateAllWidgets(context: Context) {
             val vpnActive = isVpnActive(context)
             updateAllWidgets(
                 context,
                 if (vpnActive) "Stealth ON" else "Stealth OFF",
-                if (vpnActive) COLOR_ACTIVE else COLOR_INACTIVE
+                if (vpnActive) activeColor(context) else inactiveColor(context)
             )
         }
 
@@ -54,7 +54,7 @@ class StealthWidgetProvider : AppWidgetProvider() {
             manager.updateAppWidget(widgetId, buildViews(
                 context,
                 if (vpnActive) "Stealth ON" else "Stealth OFF",
-                if (vpnActive) COLOR_ACTIVE else COLOR_INACTIVE
+                if (vpnActive) activeColor(context) else inactiveColor(context)
             ))
         }
 

--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
@@ -49,7 +49,7 @@ class StealthWidgetService : Service() {
         StealthWidgetProvider.updateAllWidgets(
             this,
             if (willBeActive) "Замораживаю..." else "Отключаю VPN...",
-            StealthWidgetProvider.COLOR_WORKING
+            StealthWidgetProvider.workingColor(this)
         )
 
         scope.launch {
@@ -59,7 +59,7 @@ class StealthWidgetService : Service() {
                 val progressJob = launch {
                     orchestrator.progressText.filterNotNull().collect { text ->
                         StealthWidgetProvider.updateAllWidgets(
-                            this@StealthWidgetService, text, StealthWidgetProvider.COLOR_WORKING
+                            this@StealthWidgetService, text, StealthWidgetProvider.workingColor(this@StealthWidgetService)
                         )
                     }
                 }
@@ -75,7 +75,9 @@ class StealthWidgetService : Service() {
                         progressJob.join()
                         if (orchestrator.lastError.value == null) {
                             StealthWidgetProvider.updateAllWidgets(
-                                this@StealthWidgetService, "Подключаю...", StealthWidgetProvider.COLOR_WORKING
+                                this@StealthWidgetService,
+                                "Подключаю...",
+                                StealthWidgetProvider.workingColor(this@StealthWidgetService)
                             )
                             withTimeoutOrNull(VPN_CONNECT_TIMEOUT_MS) {
                                 vpnClientManager.vpnActive.first { it }

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 import org.json.JSONObject
 import java.net.URL
+import sgnv.anubis.app.ui.util.renderToBitmap
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -269,10 +270,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
             Icon.createWithAdaptiveBitmap(bmp)
         } else {
-            val bmp = createBitmap(visibleSize, visibleSize)
-            val canvas = Canvas(bmp)
-            drawable.setBounds(0, 0, visibleSize, visibleSize)
-            drawable.draw(canvas)
+            val bmp = drawable.renderToBitmap(visibleSize, visibleSize)
             Icon.createWithBitmap(bmp)
         }
     }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
@@ -1,6 +1,5 @@
 package sgnv.anubis.app.ui.screens
 
-import android.graphics.Canvas
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -36,7 +35,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -44,7 +42,7 @@ import kotlinx.coroutines.launch
 import sgnv.anubis.app.data.NeverRestrictApps
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.ui.MainViewModel
-import androidx.core.graphics.createBitmap
+import sgnv.anubis.app.ui.util.renderToImageBitmap
 
 /**
  * Bottom sheet for inline add-to-group flow on the Home screen.
@@ -147,17 +145,9 @@ fun AddAppSheet(
                 items(filtered, key = { it.packageName }) { app ->
                     val isSelected = app.packageName in selectedPackages
                     val iconBitmap = remember(app.packageName) {
-                        try {
-                            val drawable = pm.getApplicationIcon(app.packageName)
-                            val bmp = createBitmap(
-                                drawable.intrinsicWidth.coerceAtLeast(1),
-                                drawable.intrinsicHeight.coerceAtLeast(1)
-                            )
-                            val canvas = Canvas(bmp)
-                            drawable.setBounds(0, 0, canvas.width, canvas.height)
-                            drawable.draw(canvas)
-                            bmp.asImageBitmap()
-                        } catch (e: Exception) { null }
+                        runCatching {
+                            pm.getApplicationIcon(app.packageName).renderToImageBitmap()
+                        }.getOrNull()
                     }
                     Row(
                         modifier = Modifier

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
@@ -1,9 +1,7 @@
 package sgnv.anubis.app.ui.screens
 
 import android.content.Context
-import android.graphics.Canvas
 import androidx.core.content.edit
-import androidx.core.graphics.createBitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -58,7 +56,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -68,6 +65,7 @@ import sgnv.anubis.app.data.DefaultRestrictedApps
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.InstalledAppInfo
 import sgnv.anubis.app.ui.MainViewModel
+import sgnv.anubis.app.ui.util.renderToImageBitmap
 
 private val grayscaleFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
 
@@ -390,20 +388,9 @@ private fun AppRow(app: InstalledAppInfo, isKnownRestricted: Boolean, onCycleGro
     val pm = context.packageManager
 
     val iconBitmap = remember(app.packageName) {
-        try {
-            val drawable = pm.getApplicationIcon(app.packageName)
-            val bmp =
-                createBitmap(
-                    drawable.intrinsicWidth.coerceAtLeast(1),
-                    drawable.intrinsicHeight.coerceAtLeast(1)
-                )
-            val canvas = Canvas(bmp)
-            drawable.setBounds(0, 0, canvas.width, canvas.height)
-            drawable.draw(canvas)
-            bmp.asImageBitmap()
-        } catch (e: Exception) {
-            null
-        }
+        runCatching {
+            pm.getApplicationIcon(app.packageName).renderToImageBitmap()
+        }.getOrNull()
     }
 
     val containerColor = when (app.group) {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -1,9 +1,7 @@
 package sgnv.anubis.app.ui.screens
 
 import android.content.Intent
-import android.graphics.Canvas
 import androidx.core.net.toUri
-import androidx.core.graphics.createBitmap
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -53,7 +51,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -65,6 +62,7 @@ import sgnv.anubis.app.service.StealthState
 import sgnv.anubis.app.shizuku.SHIZUKU_PACKAGE
 import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.ui.MainViewModel
+import sgnv.anubis.app.ui.util.renderToImageBitmap
 
 private val grayscaleFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
 
@@ -464,16 +462,9 @@ fun HomeScreen(
             catch (e: Exception) { pkg }
         }
         val iconBitmap = remember(pkg) {
-            try {
-                val drawable = pm.getApplicationIcon(pkg)
-                val bmp = createBitmap(
-                    drawable.intrinsicWidth.coerceAtLeast(1),
-                    drawable.intrinsicHeight.coerceAtLeast(1))
-                val canvas = Canvas(bmp)
-                drawable.setBounds(0, 0, canvas.width, canvas.height)
-                drawable.draw(canvas)
-                bmp.asImageBitmap()
-            } catch (e: Exception) { null }
+            runCatching {
+                pm.getApplicationIcon(pkg).renderToImageBitmap()
+            }.getOrNull()
         }
 
         ModalBottomSheet(
@@ -621,17 +612,9 @@ private fun AppIconItem(
     }
 
     val iconBitmap = remember(packageName) {
-        try {
-            val drawable = pm.getApplicationIcon(packageName)
-            val bmp = createBitmap(
-                drawable.intrinsicWidth.coerceAtLeast(1),
-                drawable.intrinsicHeight.coerceAtLeast(1)
-            )
-            val canvas = Canvas(bmp)
-            drawable.setBounds(0, 0, canvas.width, canvas.height)
-            drawable.draw(canvas)
-            bmp.asImageBitmap()
-        } catch (e: Exception) { null }
+        runCatching {
+            pm.getApplicationIcon(packageName).renderToImageBitmap()
+        }.getOrNull()
     }
 
     Column(

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/VpnClientScreen.kt
@@ -1,7 +1,5 @@
 package sgnv.anubis.app.ui.screens
 
-import androidx.core.graphics.createBitmap
-import android.graphics.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -44,13 +42,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import sgnv.anubis.app.ui.MainViewModel
+import sgnv.anubis.app.ui.util.renderToImageBitmap
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.vpn.VpnClientType
@@ -291,17 +289,9 @@ fun VpnClientScreen(
 
             if (showOtherApps) items(otherApps, key = { "app_${it.packageName}" }) { app ->
                 val iconBitmap = remember(app.packageName) {
-                    try {
-                        val drawable = pm.getApplicationIcon(app.packageName)
-                        val bmp = createBitmap(
-                            drawable.intrinsicWidth.coerceAtLeast(1),
-                            drawable.intrinsicHeight.coerceAtLeast(1)
-                        )
-                        val canvas = Canvas(bmp)
-                        drawable.setBounds(0, 0, canvas.width, canvas.height)
-                        drawable.draw(canvas)
-                        bmp.asImageBitmap()
-                    } catch (e: Exception) { null }
+                    runCatching {
+                        pm.getApplicationIcon(app.packageName).renderToImageBitmap()
+                    }.getOrNull()
                 }
                 val isSelected = isCustomSelected && selectedClient.packageName == app.packageName
                 Row(

--- a/app/src/main/java/sgnv/anubis/app/ui/util/IconBitmapUtils.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/util/IconBitmapUtils.kt
@@ -1,0 +1,26 @@
+package sgnv.anubis.app.ui.util
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.core.graphics.createBitmap
+
+private const val MIN_ICON_DIMENSION = 1
+
+fun Drawable.renderToBitmap(
+    width: Int = intrinsicWidth.coerceAtLeast(MIN_ICON_DIMENSION),
+    height: Int = intrinsicHeight.coerceAtLeast(MIN_ICON_DIMENSION)
+): Bitmap {
+    val bitmap = createBitmap(
+        width.coerceAtLeast(MIN_ICON_DIMENSION),
+        height.coerceAtLeast(MIN_ICON_DIMENSION)
+    )
+    val canvas = Canvas(bitmap)
+    setBounds(0, 0, canvas.width, canvas.height)
+    draw(canvas)
+    return bitmap
+}
+
+fun Drawable.renderToImageBitmap(): ImageBitmap = renderToBitmap().asImageBitmap()

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="widget_icon_active">#4CAF50</color>
+    <color name="widget_icon_inactive">#9E9E9E</color>
+    <color name="widget_icon_working">#FFAA00</color>
+</resources>


### PR DESCRIPTION
Для #109 

## Что

- Добавлен общий графический helper для преобразования `Drawable` в `Bitmap/ImageBitmap`;
- Цвета иконок виджета вынесены в ресурсный файл.

## Зачем

- Уменьшить дублирование кода и упростить поддержку.
- Централизовать графическую логику рендера иконок.
- Убрать хардкод цветов.

## Проверка
- Визуально:
  - иконки приложений корректно отображаются в списках и на главном экране;
  - виджет корректно меняет цвет и статус в зависимости от состояния.
