### PR TITLE
Improve startup flow on old devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Anubis">
+            android:theme="@style/Theme.Anubis.Startup">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/sgnv/anubis/app/data/db/ManagedAppDao.kt
+++ b/app/src/main/java/sgnv/anubis/app/data/db/ManagedAppDao.kt
@@ -10,6 +10,9 @@ import sgnv.anubis.app.data.model.ManagedApp
 @Dao
 interface ManagedAppDao {
 
+    @Query("SELECT * FROM managed_apps")
+    suspend fun getAll(): List<ManagedApp>
+
     @Query("SELECT * FROM managed_apps WHERE `group` = :group")
     suspend fun getByGroup(group: AppGroup): List<ManagedApp>
 

--- a/app/src/main/java/sgnv/anubis/app/data/repository/AppRepository.kt
+++ b/app/src/main/java/sgnv/anubis/app/data/repository/AppRepository.kt
@@ -58,28 +58,44 @@ class AppRepository(
         return toSelect.size
     }
 
-    suspend fun getInstalledApps(): List<InstalledAppInfo> = withContext(Dispatchers.IO) {
+    suspend fun getInstalledApps(
+        onProgress: ((processed: Int, total: Int, packageName: String) -> Unit)? = null
+    ): List<InstalledAppInfo> = withContext(Dispatchers.IO) {
         val pm = context.packageManager
         val apps = pm.getInstalledApplications(
             PackageManager.GET_META_DATA or PackageManager.MATCH_DISABLED_COMPONENTS
         )
 
-        apps.map { appInfo ->
+        val managedByPackage = dao.getAll().associateBy { it.packageName }
+
+        val totalApps = apps.size
+        val mapped = apps.mapIndexed { index, appInfo ->
             val label = try {
                 appInfo.loadLabel(pm).toString()
             } catch (e: Exception) {
                 appInfo.packageName
             }
             val isSystem = (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0
-            val managed = dao.get(appInfo.packageName)
-            InstalledAppInfo(
+            val managed = managedByPackage[appInfo.packageName]
+            val info = InstalledAppInfo(
                 packageName = appInfo.packageName,
                 label = label,
                 isSystem = isSystem,
                 group = managed?.group,
                 isDisabled = !appInfo.enabled
             )
-        }.sortedBy { it.label.lowercase() }
+            val processed = index + 1
+            if (
+                onProgress != null &&
+                (processed == 1 || processed % STARTUP_PROGRESS_STEP == 0 || processed == totalApps)
+            ) {
+                onProgress(processed, totalApps, appInfo.packageName)
+            }
+            info
+        }
+
+        val sorted = mapped.sortedBy { it.label.lowercase() }
+        sorted
     }
 
     private suspend fun getInstalledPackageNames(): Set<String> = withContext(Dispatchers.IO) {
@@ -87,5 +103,9 @@ class AppRepository(
             .getInstalledApplications(PackageManager.MATCH_DISABLED_COMPONENTS)
             .map { it.packageName }
             .toSet()
+    }
+
+    private companion object {
+        private const val STARTUP_PROGRESS_STEP = 12
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package sgnv.anubis.app.ui
+﻿package sgnv.anubis.app.ui
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -29,6 +29,7 @@ import sgnv.anubis.app.ui.screens.AppListScreen
 import sgnv.anubis.app.ui.screens.HomeScreen
 import sgnv.anubis.app.ui.screens.RecoveryScreen
 import sgnv.anubis.app.ui.screens.SettingsScreen
+import sgnv.anubis.app.ui.screens.StartupScreen
 import sgnv.anubis.app.ui.screens.VpnClientScreen
 import sgnv.anubis.app.ui.theme.AnubisTheme
 import sgnv.anubis.app.update.UpdateDialog
@@ -48,6 +49,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        setTheme(sgnv.anubis.app.R.style.Theme_Anubis)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
@@ -55,74 +57,82 @@ class MainActivity : ComponentActivity() {
             AnubisTheme {
                 val viewModel: MainViewModel = viewModel()
                 viewModelRef = viewModel
+                val startupLoading by viewModel.startupLoading.collectAsState()
+                val message by viewModel.message.collectAsState()
                 var selectedTab by rememberSaveable { mutableIntStateOf(0) }
                 var showRecovery by rememberSaveable { mutableStateOf(false) }
                 val dismissRecovery: () -> Unit = { showRecovery = false }
 
                 BackHandler(enabled = showRecovery, onBack = dismissRecovery)
 
-                Scaffold(
-                    bottomBar = {
-                        NavigationBar {
-                            NavigationBarItem(
-                                selected = selectedTab == 0,
-                                onClick = { selectedTab = 0; dismissRecovery() },
-                                icon = { Icon(Icons.Default.Home, contentDescription = null) },
-                                label = { Text("Главная") }
+                if (startupLoading) {
+                    StartupScreen(
+                        messageText = message
+                    )
+                } else {
+                    Scaffold(
+                        bottomBar = {
+                            NavigationBar {
+                                NavigationBarItem(
+                                    selected = selectedTab == 0,
+                                    onClick = { selectedTab = 0; dismissRecovery() },
+                                    icon = { Icon(Icons.Default.Home, contentDescription = null) },
+                                    label = { Text("Главная") }
+                                )
+                                NavigationBarItem(
+                                    selected = selectedTab == 1,
+                                    onClick = { selectedTab = 1; dismissRecovery() },
+                                    icon = { Icon(Icons.Default.List, contentDescription = null) },
+                                    label = { Text("Приложения") }
+                                )
+                                NavigationBarItem(
+                                    selected = selectedTab == 2,
+                                    onClick = { selectedTab = 2; dismissRecovery() },
+                                    icon = { Icon(Icons.Default.Lock, contentDescription = null) },
+                                    label = { Text("VPN") }
+                                )
+                                NavigationBarItem(
+                                    selected = selectedTab == 3,
+                                    onClick = { selectedTab = 3; dismissRecovery() },
+                                    icon = { Icon(Icons.Default.Settings, contentDescription = null) },
+                                    label = { Text("Настройки") }
+                                )
+                            }
+                        }
+                    ) { padding ->
+                        if (showRecovery) {
+                            RecoveryScreen(
+                                viewModel = viewModel,
+                                onBack = dismissRecovery,
+                                modifier = Modifier.padding(padding)
                             )
-                            NavigationBarItem(
-                                selected = selectedTab == 1,
-                                onClick = { selectedTab = 1; dismissRecovery() },
-                                icon = { Icon(Icons.Default.List, contentDescription = null) },
-                                label = { Text("Приложения") }
+                        } else when (selectedTab) {
+                            0 -> HomeScreen(
+                                viewModel = viewModel,
+                                onRequestVpnPermission = { intent ->
+                                    vpnPermissionLauncher.launch(intent)
+                                },
+                                onOpenRecovery = { showRecovery = true },
+                                modifier = Modifier.padding(padding)
                             )
-                            NavigationBarItem(
-                                selected = selectedTab == 2,
-                                onClick = { selectedTab = 2; dismissRecovery() },
-                                icon = { Icon(Icons.Default.Lock, contentDescription = null) },
-                                label = { Text("VPN") }
-                            )
-                            NavigationBarItem(
-                                selected = selectedTab == 3,
-                                onClick = { selectedTab = 3; dismissRecovery() },
-                                icon = { Icon(Icons.Default.Settings, contentDescription = null) },
-                                label = { Text("Настройки") }
+                            1 -> AppListScreen(viewModel, Modifier.padding(padding))
+                            2 -> VpnClientScreen(viewModel, Modifier.padding(padding))
+                            3 -> SettingsScreen(
+                                viewModel = viewModel,
+                                onOpenRecovery = { showRecovery = true },
+                                modifier = Modifier.padding(padding)
                             )
                         }
-                    }
-                ) { padding ->
-                    if (showRecovery) {
-                        RecoveryScreen(
-                            viewModel = viewModel,
-                            onBack = dismissRecovery,
-                            modifier = Modifier.padding(padding)
-                        )
-                    } else when (selectedTab) {
-                        0 -> HomeScreen(
-                            viewModel = viewModel,
-                            onRequestVpnPermission = { intent ->
-                                vpnPermissionLauncher.launch(intent)
-                            },
-                            onOpenRecovery = { showRecovery = true },
-                            modifier = Modifier.padding(padding)
-                        )
-                        1 -> AppListScreen(viewModel, Modifier.padding(padding))
-                        2 -> VpnClientScreen(viewModel, Modifier.padding(padding))
-                        3 -> SettingsScreen(
-                            viewModel = viewModel,
-                            onOpenRecovery = { showRecovery = true },
-                            modifier = Modifier.padding(padding)
-                        )
-                    }
 
-                    val updateInfo by viewModel.updateInfo.collectAsState()
-                    updateInfo?.let { info ->
-                        if (info.isUpdateAvailable) {
-                            UpdateDialog(
-                                info = info,
-                                onDismiss = { viewModel.dismissUpdateDialog() },
-                                onSkip = { viewModel.skipCurrentUpdate() },
-                            )
+                        val updateInfo by viewModel.updateInfo.collectAsState()
+                        updateInfo?.let { info ->
+                            if (info.isUpdateAvailable) {
+                                UpdateDialog(
+                                    info = info,
+                                    onDismiss = { viewModel.dismissUpdateDialog() },
+                                    onSkip = { viewModel.skipCurrentUpdate() },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 import org.json.JSONObject
 import java.net.URL
+import java.util.concurrent.atomic.AtomicBoolean
+import sgnv.anubis.app.R
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -113,6 +115,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _resetCompleted = MutableSharedFlow<Int>()
     val resetCompleted: SharedFlow<Int> = _resetCompleted
+    private val _startupLoading = MutableStateFlow(true)
+    val startupLoading: StateFlow<Boolean> = _startupLoading
+    private val _message = MutableStateFlow("")
+    val message: StateFlow<String> = _message
+    private val startupLoadingFinalized = AtomicBoolean(false)
 
     init {
         // VpnClientManager is started in AnubisApp.onCreate — don't re-register here.
@@ -393,7 +400,29 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     /** Suspend version for pull-to-refresh: caller awaits completion, then dismisses the spinner. */
     suspend fun refreshInstalledAppsSync() {
-        _installedApps.value = repository.getInstalledApps()
+        try {
+            _installedApps.value = repository.getInstalledApps { processed, total, packageName ->
+                if (!startupLoadingFinalized.get()) {
+                    val status = getApplication<Application>().getString(
+                        R.string.startup_status_scanning_progress,
+                        processed,
+                        total
+                    )
+                    _message.value = if (packageName.isBlank()) {
+                        status
+                    } else {
+                        "$status\n$packageName"
+                    }
+                }
+            }
+        } finally {
+            if (startupLoadingFinalized.compareAndSet(false, true)) {
+                _message.value = getApplication<Application>()
+                    .getString(R.string.startup_status_preparing_launch)
+                delay(250)
+                _startupLoading.value = false
+            }
+        }
     }
 
     fun loadGroupedApps() {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/StartupScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/StartupScreen.kt
@@ -1,0 +1,53 @@
+package sgnv.anubis.app.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.BottomCenter
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import sgnv.anubis.app.BuildConfig
+import sgnv.anubis.app.R
+
+@Composable
+fun StartupScreen(
+    messageText: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.app_name),
+                style = MaterialTheme.typography.headlineMedium
+            )
+            if (messageText.isNotBlank()) {
+                Text(
+                    text = messageText,
+                    modifier = Modifier.padding(top = 12.dp, start = 24.dp, end = 24.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+        Text(
+            text = stringResource(R.string.startup_version_format, BuildConfig.VERSION_NAME),
+            modifier = Modifier
+                .align(BottomCenter)
+                .navigationBarsPadding()
+                .padding(bottom = 12.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/main/res/drawable/launch_screen.xml
+++ b/app/src/main/res/drawable/launch_screen.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/white" />
+    <item
+        android:gravity="center"
+        android:drawable="@mipmap/ic_launcher" />
+</layer-list>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Anubis.Startup" parent="Theme.Anubis">
+        <item name="android:windowSplashScreenBackground">@android:color/white</item>
+        <item name="android:windowSplashScreenAnimatedIcon">@mipmap/ic_launcher</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,8 @@
 <resources>
     <string name="app_name">Anubis</string>
     <string name="tile_label">Anubis</string>
+
+    <string name="startup_status_scanning_progress">Сканирование приложений: %1$d / %2$d</string>
+    <string name="startup_status_preparing_launch">Подготовка к запуску…</string>
+    <string name="startup_version_format">Версия %1$s</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.Anubis" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.Anubis.Startup" parent="Theme.Anubis">
+        <item name="android:windowBackground">@drawable/launch_screen</item>
+    </style>
 </resources>


### PR DESCRIPTION
Изменения по задаче **«Долгий старт на старом телефоне #111»**:

## Что сделано
- Добавлен стартовый UX в два этапа:
  - системный splash;
  - compose-экран загрузки до готовности главного экрана.
   - отображение названия приложения;
   - объединённое сообщение загрузки (статус + имя текущего пакета);
   - вывод версии приложения внизу экрана.
- Оптимизирована загрузка списка приложений: использован батч `dao.getAll()` вместо повторных точечных запросов к БД, что немного ускорило загрузку.
- Все новые UI-тексты вынесены в `strings.xml`.

## Результат
- Улучшен perceived startup: пользователь сразу видит осмысленный экран и прогресс.
- Уменьшена нагрузка на старте за счёт оптимизации получения managed-приложений.

## Ручная проверка сценария старта:
  - отображается прогресс сканирования;
  - отображается финальный статус подготовки;
  - показывается версия приложения на startup-экране.