### PR TITLE
Add inactive Shizuku notifications across app

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/ShortcutActivity.kt
@@ -1,10 +1,12 @@
 package sgnv.anubis.app.service
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.settings.AppSettings
+import sgnv.anubis.app.shizuku.shizukuUnavailableMessageRes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -29,7 +31,7 @@ class ShortcutActivity : ComponentActivity() {
 
         val data = intent.data
         val isUrlLaunch = data?.scheme == URL_SCHEME
-        val packageName = if (isUrlLaunch) data?.host else intent.getStringExtra("package")
+        val packageName = if (isUrlLaunch) data.host else intent.getStringExtra(EXTRA_PACKAGE)
         if (packageName.isNullOrBlank()) { finish(); return }
 
         val app = applicationContext as AnubisApp
@@ -42,6 +44,12 @@ class ShortcutActivity : ComponentActivity() {
         val client = AppSettings.loadSelectedVpnClient(this)
 
         CoroutineScope(Dispatchers.Main).launch {
+            val unavailableRes = shizukuUnavailableMessageRes(shizukuManager.status.value)
+            if (unavailableRes != null) {
+                Toast.makeText(this@ShortcutActivity, getString(unavailableRes), Toast.LENGTH_SHORT).show()
+                finish()
+                return@launch
+            }
             shizukuManager.awaitUserService()
 
             // Resolve group. Repository is authoritative; extras are a legacy fallback
@@ -51,7 +59,7 @@ class ShortcutActivity : ComponentActivity() {
             val group = when {
                 managedGroup != null -> managedGroup
                 isUrlLaunch -> { finish(); return@launch }
-                else -> intent.getStringExtra("group")
+                else -> intent.getStringExtra(EXTRA_GROUP)
                     ?.let { runCatching { AppGroup.valueOf(it) }.getOrNull() }
                     ?: AppGroup.LAUNCH_VPN
             }
@@ -80,5 +88,7 @@ class ShortcutActivity : ComponentActivity() {
 
     companion object {
         const val URL_SCHEME = "anubis"
+        const val EXTRA_PACKAGE = "package"
+        const val EXTRA_GROUP = "group"
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthTileService.kt
@@ -5,6 +5,7 @@ import android.service.quicksettings.TileService
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
 import sgnv.anubis.app.settings.AppSettings
+import sgnv.anubis.app.shizuku.ShizukuStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -38,6 +39,9 @@ class StealthTileService : TileService() {
 
         scope.launch {
             try {
+                if (shizukuManager.status.value != ShizukuStatus.READY) {
+                    return@launch
+                }
                 shizukuManager.awaitUserService()
 
                 withTimeoutOrNull(TOTAL_TOGGLE_TIMEOUT_MS) {

--- a/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthWidgetService.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.os.IBinder
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.settings.AppSettings
+import sgnv.anubis.app.shizuku.ShizukuStatus
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientType
 import kotlinx.coroutines.CoroutineScope
@@ -54,6 +55,9 @@ class StealthWidgetService : Service() {
 
         scope.launch {
             try {
+                if (shizukuManager.status.value != ShizukuStatus.READY) {
+                    return@launch
+                }
                 shizukuManager.awaitUserService()
 
                 val progressJob = launch {

--- a/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuStatusText.kt
+++ b/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuStatusText.kt
@@ -1,0 +1,12 @@
+package sgnv.anubis.app.shizuku
+
+import androidx.annotation.StringRes
+import sgnv.anubis.app.R
+
+@StringRes
+fun shizukuUnavailableMessageRes(status: ShizukuStatus): Int? = when (status) {
+    ShizukuStatus.NOT_INSTALLED -> R.string.shizuku_toast_not_installed
+    ShizukuStatus.NOT_RUNNING -> R.string.shizuku_toast_not_running
+    ShizukuStatus.NO_PERMISSION -> R.string.shizuku_toast_no_permission
+    ShizukuStatus.READY -> null
+}

--- a/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package sgnv.anubis.app.ui
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -17,6 +18,7 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -24,7 +26,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.collectLatest
 import sgnv.anubis.app.ui.screens.AppListScreen
 import sgnv.anubis.app.ui.screens.HomeScreen
 import sgnv.anubis.app.ui.screens.LogScreen
@@ -58,6 +62,7 @@ class MainActivity : ComponentActivity() {
             AnubisTheme {
                 val viewModel: MainViewModel = viewModel()
                 viewModelRef = viewModel
+                val context = LocalContext.current
                 val startupLoading by viewModel.startupLoading.collectAsState()
                 val message by viewModel.message.collectAsState()
                 var selectedTab by rememberSaveable { mutableIntStateOf(0) }
@@ -69,6 +74,12 @@ class MainActivity : ComponentActivity() {
                     selectedTab = tab
                     dismissRecovery()
                     dismissJournal()
+                }
+
+                LaunchedEffect(viewModel) {
+                    viewModel.toastMessages.collectLatest { messageText ->
+                        Toast.makeText(context, messageText, Toast.LENGTH_SHORT).show()
+                    }
                 }
 
                 BackHandler(enabled = showRecovery || showJournal) {

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -14,6 +14,7 @@ import sgnv.anubis.app.service.StealthVpnService
 import sgnv.anubis.app.service.VpnMonitorService
 import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.shizuku.ShizukuStatus
+import sgnv.anubis.app.shizuku.shizukuUnavailableMessageRes
 import sgnv.anubis.app.update.UpdateChecker
 import sgnv.anubis.app.update.UpdateInfo
 import sgnv.anubis.app.vpn.SelectedVpnClient
@@ -122,6 +123,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _resetCompleted = MutableSharedFlow<Int>()
     val resetCompleted: SharedFlow<Int> = _resetCompleted
+    private val _toastMessages = MutableSharedFlow<String>(extraBufferCapacity = 8)
+    val toastMessages: SharedFlow<String> = _toastMessages
     private val _startupLoading = MutableStateFlow(true)
     val startupLoading: StateFlow<Boolean> = _startupLoading
     private val _message = MutableStateFlow("")
@@ -174,6 +177,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun toggleStealth() {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             if (stealthState.value == StealthState.DISABLED) {
                 orchestrator.enable(_selectedVpnClient.value)
@@ -192,12 +196,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun launchWithVpn(packageName: String) {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             orchestrator.launchWithVpn(packageName, _selectedVpnClient.value)
         }
     }
 
     fun launchLocal(packageName: String) {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             val detectedPkg = vpnClientManager.activeVpnPackage.value
             val detectedClient = vpnClientManager.activeVpnClient.value
@@ -212,6 +218,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun toggleAppFrozen(packageName: String) {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             orchestrator.toggleAppFrozen(packageName)
             loadGroupedApps()
@@ -356,6 +363,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun unfreezeAllAndClear() {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             val allManaged = repository.getAllManagedPackages()
             var unfrozenCount = 0
@@ -380,6 +388,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     /** Emergency: scan PM for all user-disabled apps and unfreeze them.
      *  Covers the case when Anubis was reinstalled and DB is empty but apps are still frozen. */
     fun unfreezeAllUserDisabled() {
+        if (!ensureShizukuReadyForAction()) return
         viewModelScope.launch {
             val pm = getApplication<Application>().packageManager
             val disabled = withContext(Dispatchers.IO) {
@@ -673,6 +682,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     override fun onCleared() {
         // VpnClientManager is a process-wide singleton in AnubisApp — don't stop it here.
         super.onCleared()
+    }
+
+    private fun ensureShizukuReadyForAction(): Boolean {
+        val status = shizukuManager.status.value
+        val messageRes = shizukuUnavailableMessageRes(status) ?: return true
+        _toastMessages.tryEmit(getApplication<Application>().getString(messageRes))
+        return false
     }
 }
 

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -63,6 +63,7 @@ import sgnv.anubis.app.data.model.ManagedApp
 import sgnv.anubis.app.service.StealthState
 import sgnv.anubis.app.shizuku.SHIZUKU_PACKAGE
 import sgnv.anubis.app.shizuku.ShizukuStatus
+import sgnv.anubis.app.shizuku.shizukuUnavailableMessageRes
 import sgnv.anubis.app.ui.MainViewModel
 import sgnv.anubis.app.ui.util.renderToImageBitmap
 
@@ -187,7 +188,7 @@ fun HomeScreen(
                             if (vpnIntent != null) { onRequestVpnPermission(vpnIntent); return@Switch }
                             viewModel.toggleStealth()
                         },
-                        enabled = !isTransitioning && shizukuStatus == ShizukuStatus.READY
+                        enabled = true
                     )
                 }
             }
@@ -226,18 +227,16 @@ fun HomeScreen(
 
         if (shizukuStatus != ShizukuStatus.READY) {
             val context = LocalContext.current
+            val shizukuStatusTextRes = shizukuUnavailableMessageRes(shizukuStatus)
             Spacer(Modifier.height(8.dp))
             Card(Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)) {
                 Column(Modifier.padding(12.dp)) {
-                    Text(
-                        when (shizukuStatus) {
-                            ShizukuStatus.NOT_INSTALLED -> "Shizuku не установлен"
-                            ShizukuStatus.NOT_RUNNING -> "Shizuku не запущен"
-                            ShizukuStatus.NO_PERMISSION -> "Нет разрешения Shizuku"
-                            ShizukuStatus.READY -> "" // unreachable
-                        },
-                        style = MaterialTheme.typography.bodySmall
-                    )
+                    shizukuStatusTextRes?.let { textRes ->
+                        Text(
+                            stringResource(textRes),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
                     Row(Modifier.padding(top = 8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         when (shizukuStatus) {
                             ShizukuStatus.NOT_INSTALLED -> Button(onClick = {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/RecoveryScreen.kt
@@ -1,5 +1,6 @@
 package sgnv.anubis.app.ui.screens
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -7,19 +8,24 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons.AutoMirrored.Filled
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,8 +33,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import sgnv.anubis.app.R
+import sgnv.anubis.app.shizuku.shizukuUnavailableMessageRes
 import sgnv.anubis.app.ui.MainViewModel
 
 @Composable
@@ -38,6 +47,7 @@ fun RecoveryScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val shizukuStatus by viewModel.shizukuStatus.collectAsState()
 
     var showResetDialog by remember { mutableStateOf(false) }
     val dismissResetDialog: () -> Unit = { showResetDialog = false }
@@ -45,12 +55,20 @@ fun RecoveryScreen(
     var showScanDialog by remember { mutableStateOf(false) }
     val dismissScanDialog: () -> Unit = { showScanDialog = false }
 
+    val requireShizukuReady: () -> Boolean = {
+        val messageRes = shizukuUnavailableMessageRes(shizukuStatus)
+        messageRes == null || run {
+            Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
+            false
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.resetCompleted.collect { count ->
-            android.widget.Toast.makeText(
+            Toast.makeText(
                 context,
-                "Разморожено приложений: $count. Группы очищены.",
-                android.widget.Toast.LENGTH_LONG
+                context.getString(R.string.recovery_reset_completed, count),
+                Toast.LENGTH_LONG
             ).show()
             onBack()
         }
@@ -64,14 +82,16 @@ fun RecoveryScreen(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             TextButton(onClick = onBack) {
-                Text("‹ Назад", style = MaterialTheme.typography.labelLarge)
+                Icon(imageVector = Filled.ArrowBack, contentDescription = null)
+                Spacer(Modifier.width(4.dp))
+                Text(stringResource(R.string.recovery_back), style = MaterialTheme.typography.labelLarge)
             }
         }
 
         Spacer(Modifier.height(8.dp))
 
         Text(
-            "Восстановление",
+            stringResource(R.string.recovery_title),
             style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.Bold
         )
@@ -79,10 +99,7 @@ fun RecoveryScreen(
         Spacer(Modifier.height(8.dp))
 
         Text(
-            "Если после использования Anubis с рабочего стола пропали иконки или приложения не открываются — " +
-            "выберите один из сценариев восстановления ниже.\n\n" +
-            "Ярлыки на рабочем столе автоматически не вернутся — это ограничение лаунчеров Android. " +
-            "Приложения будут доступны в системном меню и поиске, оттуда их можно перетащить обратно.",
+            stringResource(R.string.recovery_intro),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -93,23 +110,25 @@ fun RecoveryScreen(
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    "Обычный сброс",
+                    stringResource(R.string.recovery_normal_title),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    "Разморозить только те приложения, которые замораживал Anubis, и очистить группы. " +
-                    "Безопасный вариант — не трогает то, что вы отключали вручную.",
+                    stringResource(R.string.recovery_normal_description),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(12.dp))
                 Button(
-                    onClick = { showResetDialog = true },
+                    onClick = {
+                        if (!requireShizukuReady()) return@Button
+                        showResetDialog = true
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Сбросить Anubis")
+                    Text(stringResource(R.string.recovery_reset_anubis_button))
                 }
             }
         }
@@ -125,28 +144,29 @@ fun RecoveryScreen(
         ) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    "Аварийная разморозка",
+                    stringResource(R.string.recovery_emergency_title),
                     style = MaterialTheme.typography.titleSmall,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onErrorContainer
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    "Найти и разморозить ВСЕ отключённые пользовательские приложения. " +
-                    "Нужно, если вы переустанавливали Anubis и данные о группах утеряны. " +
-                    "Внимание: разморозит и те приложения, которые вы отключали вручную через настройки Android.",
+                    stringResource(R.string.recovery_emergency_description),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onErrorContainer
                 )
                 Spacer(Modifier.height(12.dp))
                 OutlinedButton(
-                    onClick = { showScanDialog = true },
+                    onClick = {
+                        if (!requireShizukuReady()) return@OutlinedButton
+                        showScanDialog = true
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.outlinedButtonColors(
                         contentColor = MaterialTheme.colorScheme.onErrorContainer
                     )
                 ) {
-                    Text("Разморозить все отключённые")
+                    Text(stringResource(R.string.recovery_unfreeze_all_disabled_button))
                 }
             }
         }
@@ -157,11 +177,10 @@ fun RecoveryScreen(
     if (showResetDialog) {
         AlertDialog(
             onDismissRequest = dismissResetDialog,
-            title = { Text("Сбросить Anubis?") },
+            title = { Text(stringResource(R.string.recovery_reset_dialog_title)) },
             text = {
                 Text(
-                    "Все приложения в группах будут разморожены, группы очищены. " +
-                    "Anubis перестанет чем-либо управлять до повторной настройки."
+                    stringResource(R.string.recovery_reset_dialog_text)
                 )
             },
             confirmButton = {
@@ -169,11 +188,11 @@ fun RecoveryScreen(
                     viewModel.unfreezeAllAndClear()
                     dismissResetDialog()
                 }) {
-                    Text("Сбросить", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.recovery_reset_confirm), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
-                TextButton(onClick = dismissResetDialog) { Text("Отмена") }
+                TextButton(onClick = dismissResetDialog) { Text(stringResource(R.string.common_cancel)) }
             }
         )
     }
@@ -181,12 +200,10 @@ fun RecoveryScreen(
     if (showScanDialog) {
         AlertDialog(
             onDismissRequest = dismissScanDialog,
-            title = { Text("Разморозить все отключённые?") },
+            title = { Text(stringResource(R.string.recovery_unfreeze_disabled_dialog_title)) },
             text = {
                 Text(
-                    "Anubis найдёт все отключённые пользовательские приложения на устройстве и разморозит их " +
-                    "через Shizuku. Это коснётся и тех приложений, которые вы отключали вручную через настройки Android.\n\n" +
-                    "Системные приложения не затрагиваются."
+                    stringResource(R.string.recovery_unfreeze_disabled_dialog_text)
                 )
             },
             confirmButton = {
@@ -194,11 +211,11 @@ fun RecoveryScreen(
                     viewModel.unfreezeAllUserDisabled()
                     dismissScanDialog()
                 }) {
-                    Text("Разморозить всё", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.recovery_unfreeze_all_confirm), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
-                TextButton(onClick = dismissScanDialog) { Text("Отмена") }
+                TextButton(onClick = dismissScanDialog) { Text(stringResource(R.string.common_cancel)) }
             }
         )
     }

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -13,7 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -48,12 +49,12 @@ fun SettingsScreen(
             .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ) {
-        Text("Настройки", style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Bold)
+        Text("Настройки", style = typography.headlineSmall, fontWeight = FontWeight.Bold)
 
         Spacer(Modifier.height(24.dp))
 
         // Background monitoring
-        Text("Мониторинг", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text("Мониторинг", style = typography.titleMedium, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(8.dp))
 
         val bgMonitoring by viewModel.backgroundMonitoring.collectAsState()
@@ -65,11 +66,11 @@ fun SettingsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Фоновый мониторинг VPN", style = MaterialTheme.typography.bodyMedium)
+                    Text("Фоновый мониторинг VPN", style = typography.bodyMedium)
                     Text(
                         "Автозаморозка при изменении VPN вне Anubis",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        style = typography.bodySmall,
+                        color = colorScheme.onSurfaceVariant
                     )
                 }
                 androidx.compose.material3.Switch(
@@ -86,7 +87,7 @@ fun SettingsScreen(
         Card(
             modifier = Modifier.fillMaxWidth(),
             colors = androidx.compose.material3.CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
+                containerColor = colorScheme.surfaceVariant
             )
         ) {
             Row(
@@ -97,18 +98,18 @@ fun SettingsScreen(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         "Размораживать группы при включении/отключении VPN",
-                        style = MaterialTheme.typography.bodyMedium
+                        style = typography.bodyMedium
                     )
                     Text(
                         "После включения VPN размораживает «Только VPN», после отключения — «Без VPN».",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        style = typography.bodySmall,
+                        color = colorScheme.onSurfaceVariant
                     )
                     Spacer(Modifier.height(6.dp))
                     Text(
                         "Устаревший переключатель. Будет удалён в v0.1.5. Вместо него используйте группу «Без VPN + уведомления» для нужных приложений.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error
+                        style = typography.bodySmall,
+                        color = colorScheme.error
                     )
                 }
                 androidx.compose.material3.Switch(
@@ -129,12 +130,12 @@ fun SettingsScreen(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         stringResource(R.string.settings_launcher_safe_mode_title),
-                        style = MaterialTheme.typography.bodyMedium
+                        style = typography.bodyMedium
                     )
                     Text(
                         stringResource(R.string.settings_launcher_safe_mode_description),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        style = typography.bodySmall,
+                        color = colorScheme.onSurfaceVariant
                     )
                 }
                 androidx.compose.material3.Switch(
@@ -148,7 +149,7 @@ fun SettingsScreen(
 
         // Shizuku status — clickable when not ready: opens Shizuku activity, the download page,
         // or requests permission depending on the state (issue #84).
-        Text("Shizuku", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text("Shizuku", style = typography.titleMedium, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(8.dp))
         val shizukuContext = LocalContext.current
         val shizukuCardModifier = when (shizukuStatus) {
@@ -159,36 +160,43 @@ fun SettingsScreen(
                 if (launch != null) shizukuContext.startActivity(launch)
             }
             ShizukuStatus.NOT_INSTALLED -> Modifier.fillMaxWidth().clickable {
-                shizukuContext.startActivity(Intent(Intent.ACTION_VIEW, "https://shizuku.rikka.app/download/".toUri()))
+                shizukuContext.startActivity(
+                    Intent(Intent.ACTION_VIEW, SettingsScreenConstants.SHIZUKU_DOWNLOAD_URL.toUri())
+                )
             }
         }
         Card(modifier = shizukuCardModifier) {
             Row(Modifier.fillMaxWidth().padding(16.dp), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Статус", style = MaterialTheme.typography.bodyMedium)
+                    Text(stringResource(R.string.settings_shizuku_status_label), style = typography.bodyMedium)
                     if (shizukuStatus != ShizukuStatus.READY) {
-                        Text(
-                            when (shizukuStatus) {
-                                ShizukuStatus.NOT_INSTALLED -> "Нажмите, чтобы скачать"
-                                ShizukuStatus.NOT_RUNNING -> "Нажмите, чтобы открыть Shizuku"
-                                ShizukuStatus.NO_PERMISSION -> "Нажмите, чтобы выдать разрешение"
-                                ShizukuStatus.READY -> "" // unreachable
-                            },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                        val hintRes = when (shizukuStatus) {
+                            ShizukuStatus.NOT_INSTALLED -> R.string.settings_shizuku_hint_not_installed
+                            ShizukuStatus.NOT_RUNNING -> R.string.settings_shizuku_hint_not_running
+                            ShizukuStatus.NO_PERMISSION -> R.string.settings_shizuku_hint_no_permission
+                            ShizukuStatus.READY -> null
+                        }
+                        hintRes?.let {
+                            Text(
+                                stringResource(it),
+                                style = typography.bodySmall,
+                                color = colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
                 Text(
-                    when (shizukuStatus) {
-                        ShizukuStatus.READY -> "Подключён"
-                        ShizukuStatus.NO_PERMISSION -> "Нет разрешения"
-                        ShizukuStatus.NOT_RUNNING -> "Не запущен"
-                        ShizukuStatus.NOT_INSTALLED -> "Не установлен"
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
+                    stringResource(
+                        when (shizukuStatus) {
+                            ShizukuStatus.READY -> R.string.settings_shizuku_value_ready
+                            ShizukuStatus.NO_PERMISSION -> R.string.settings_shizuku_value_no_permission
+                            ShizukuStatus.NOT_RUNNING -> R.string.settings_shizuku_value_not_running
+                            ShizukuStatus.NOT_INSTALLED -> R.string.settings_shizuku_value_not_installed
+                        }
+                    ),
+                    style = typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
-                    color = if (shizukuStatus == ShizukuStatus.READY) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                    color = if (shizukuStatus == ShizukuStatus.READY) colorScheme.primary else colorScheme.error
                 )
             }
         }
@@ -236,30 +244,34 @@ fun SettingsScreen(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("Восстановление", style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Medium)
                     Text(
-                        "Разморозить приложения, очистить группы",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        stringResource(R.string.recovery_title),
+                        style = typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        stringResource(R.string.settings_recovery_description),
+                        style = typography.bodySmall,
+                        color = colorScheme.onSurfaceVariant
                     )
                 }
-                Text("›", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("›", style = typography.headlineSmall, color = colorScheme.onSurfaceVariant)
             }
         }
 
         Spacer(Modifier.height(24.dp))
 
         // About
-        Text("О приложении", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+        Text("О приложении", style = typography.titleMedium, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(8.dp))
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text("Anubis v${sgnv.anubis.app.BuildConfig.VERSION_NAME}",
-                    style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold)
+                    style = typography.bodyLarge, fontWeight = FontWeight.Bold)
                 Text(
                     "Управляет группами приложений и VPN-подключением. Изолирует приложения по группам для контроля сетевого доступа.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    style = typography.bodySmall,
+                    color = colorScheme.onSurfaceVariant
                 )
                 Spacer(Modifier.height(12.dp))
 
@@ -273,11 +285,11 @@ fun SettingsScreen(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Column(modifier = Modifier.weight(1f)) {
-                        Text("Проверять обновления", style = MaterialTheme.typography.bodyMedium)
+                        Text("Проверять обновления", style = typography.bodyMedium)
                         Text(
                             "Автоматическая проверка при запуске",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            style = typography.bodySmall,
+                            color = colorScheme.onSurfaceVariant
                         )
                     }
                     androidx.compose.material3.Switch(
@@ -295,15 +307,15 @@ fun SettingsScreen(
                     ) {
                         Text(
                             if (updateCheckInProgress) "Проверка..." else "Проверить сейчас",
-                            style = MaterialTheme.typography.labelMedium
+                            style = typography.labelMedium
                         )
                     }
                     updateInfo?.let { info ->
                         if (!info.isUpdateAvailable) {
                             Text(
                                 "У вас последняя версия",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                style = typography.bodySmall,
+                                color = colorScheme.onSurfaceVariant
                             )
                         }
                     }
@@ -312,17 +324,27 @@ fun SettingsScreen(
                 val context = LocalContext.current
                 Column {
                     TextButton(onClick = {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, "https://github.com/sogonov/anubis".toUri()))
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, SettingsScreenConstants.GITHUB_URL.toUri())
+                        )
                     }) {
-                        Text("GitHub", style = MaterialTheme.typography.labelMedium)
+                        Text("GitHub", style = typography.labelMedium)
                     }
                     TextButton(onClick = {
-                        context.startActivity(Intent(Intent.ACTION_VIEW, "https://t.me/anubis_app".toUri()))
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, SettingsScreenConstants.TELEGRAM_URL.toUri())
+                        )
                     }) {
-                        Text("Telegram", style = MaterialTheme.typography.labelMedium)
+                        Text("Telegram", style = typography.labelMedium)
                     }
                 }
             }
         }
     }
+}
+
+private object SettingsScreenConstants {
+    const val SHIZUKU_DOWNLOAD_URL = "https://shizuku.rikka.app/download/"
+    const val GITHUB_URL = "https://github.com/sogonov/anubis"
+    const val TELEGRAM_URL = "https://t.me/anubis_app"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,34 @@
     <string name="log_screen_clear_confirm_title">Очистить журнал?</string>
     <string name="log_screen_clear_confirm_message">Все записи журнала будут удалены.</string>
     <string name="log_screen_clear_confirm_action">Очистить</string>
+
+    <string name="shizuku_toast_not_installed">Функция недоступна: Shizuku не установлен</string>
+    <string name="shizuku_toast_not_running">Функция недоступна: Shizuku не запущен</string>
+    <string name="shizuku_toast_no_permission">Функция недоступна: нет разрешения Shizuku</string>
+
+    <string name="recovery_title">Восстановление</string>
+    <string name="recovery_back">Назад</string>
+    <string name="recovery_reset_completed">Разморожено приложений: %1$d. Группы очищены.</string>
+    <string name="recovery_intro">Если после использования Anubis с рабочего стола пропали иконки или приложения не открываются — выберите один из сценариев восстановления ниже.\n\nЯрлыки на рабочем столе автоматически не вернутся — это ограничение лаунчеров Android. Приложения будут доступны в системном меню и поиске, оттуда их можно перетащить обратно.</string>
+    <string name="recovery_normal_title">Обычный сброс</string>
+    <string name="recovery_normal_description">Разморозить только те приложения, которые замораживал Anubis, и очистить группы. Безопасный вариант — не трогает то, что вы отключали вручную.</string>
+    <string name="recovery_reset_anubis_button">Сбросить Anubis</string>
+    <string name="recovery_emergency_title">Аварийная разморозка</string>
+    <string name="recovery_emergency_description">Найти и разморозить ВСЕ отключённые пользовательские приложения. Нужно, если вы переустанавливали Anubis и данные о группах утеряны. Внимание: разморозит и те приложения, которые вы отключали вручную через настройки Android.</string>
+    <string name="recovery_unfreeze_all_disabled_button">Разморозить все отключённые</string>
+    <string name="recovery_reset_dialog_title">Сбросить Anubis?</string>
+    <string name="recovery_reset_dialog_text">Все приложения в группах будут разморожены, группы очищены. Anubis перестанет чем-либо управлять до повторной настройки.</string>
+    <string name="recovery_reset_confirm">Сбросить</string>
+    <string name="recovery_unfreeze_disabled_dialog_title">Разморозить все отключённые?</string>
+    <string name="recovery_unfreeze_disabled_dialog_text">Anubis найдёт все отключённые пользовательские приложения на устройстве и разморозит их через Shizuku. Это коснётся и тех приложений, которые вы отключали вручную через настройки Android.\n\nСистемные приложения не затрагиваются.</string>
+    <string name="recovery_unfreeze_all_confirm">Разморозить всё</string>
+    <string name="settings_recovery_description">Разморозить приложения, очистить группы</string>
+    <string name="settings_shizuku_status_label">Статус</string>
+    <string name="settings_shizuku_hint_not_installed">Нажмите, чтобы скачать</string>
+    <string name="settings_shizuku_hint_not_running">Нажмите, чтобы открыть Shizuku</string>
+    <string name="settings_shizuku_hint_no_permission">Нажмите, чтобы выдать разрешение</string>
+    <string name="settings_shizuku_value_ready">Подключён</string>
+    <string name="settings_shizuku_value_no_permission">Нет разрешения</string>
+    <string name="settings_shizuku_value_not_running">Не запущен</string>
+    <string name="settings_shizuku_value_not_installed">Не установлен</string>
 </resources>


### PR DESCRIPTION
## Что сделано

Добавлены уведомления о недоступности Shizuku и унифицирована обработка этого состояния в основных пользовательских сценариях.

- Добавлена единая карта статусов Shizuku в текстовые сообщения для UI/Toast.
- Действия, зависящие от Shizuku, теперь проверяют готовность перед выполнением и показывают понятное сообщение пользователю, если Shizuku не готов.
- На главном экране переключатель остаётся доступным для нажатия, а ошибка Shizuku объясняется через уведомление.
- В `ShortcutActivity` добавлена проверка статуса Shizuku с ранним выходом и показом сообщения.
- Для `StealthTileService` и `StealthWidgetService` добавлен ранний выход при неготовом Shizuku (без Toast в этих контекстах).
- В `RecoveryScreen` добавлена ранняя проверка Shizuku до запуска сценариев восстановления.
- В `SettingsScreen` тексты, связанные со статусом Shizuku и описанием восстановления, вынесены в ресурсы.
- Добавлены новые строки в `strings.xml` для сообщений о недоступности Shizuku и связанных UI-текстов.
- Некоторые старые строки перенесены в `strings.xml`


## Зачем

- Пользователь сразу получает понятную причину, почему действие не выполняется.
- Убраны «молчаливые» неуспешные действия при неактивном/недоступном Shizuku.


## Проверка

1. Перевести Shizuku в состояния: не установлен / не запущен / нет разрешения.
2. Проверить действия на главном экране, в recovery-сценариях и через ярлык:
   - при неготовом Shizuku показывается уведомление о причине;
   - действие не выполняется.
3. Перевести Shizuku в `READY`:
   - те же действия должны отрабатывать штатно.
4. Проверить плитку и виджет:
   - при неготовом Shizuku не выполняют действие и не показывают лишних сообщений.