### PR TITLE
Improve group management UX across home and app list screens

### DIFF
--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AddAppSheet.kt
@@ -94,10 +94,16 @@ fun AddAppSheet(
     }
 
     val groupLabel = when (targetGroup) {
-        AppGroup.LOCAL -> "Без VPN"
-        AppGroup.LOCAL_AUTO_UNFREEZE -> "Без VPN + уведомления"
-        AppGroup.VPN_ONLY -> "Только VPN"
-        AppGroup.LAUNCH_VPN -> "С VPN"
+        AppGroup.LOCAL -> stringResource(R.string.group_label_no_vpn)
+        AppGroup.LOCAL_AUTO_UNFREEZE -> stringResource(R.string.add_app_sheet_group_local_auto_full)
+        AppGroup.VPN_ONLY -> stringResource(R.string.app_list_legend_label_vpn_only)
+        AppGroup.LAUNCH_VPN -> stringResource(R.string.group_label_with_vpn)
+    }
+    val groupColor = when (targetGroup) {
+        AppGroup.LOCAL -> MaterialTheme.colorScheme.error
+        AppGroup.LOCAL_AUTO_UNFREEZE -> MaterialTheme.colorScheme.secondary
+        AppGroup.VPN_ONLY -> MaterialTheme.colorScheme.tertiary
+        AppGroup.LAUNCH_VPN -> MaterialTheme.colorScheme.primary
     }
 
     ModalBottomSheet(
@@ -109,18 +115,27 @@ fun AddAppSheet(
                 .padding(horizontal = 16.dp)
                 .imePadding()
         ) {
-            Text(
-                "Добавить в «$groupLabel»",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    stringResource(R.string.add_app_sheet_add_to_prefix),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    stringResource(R.string.add_app_sheet_group_quoted, groupLabel),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = groupColor
+                )
+            }
             Spacer(Modifier.height(8.dp))
             OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = true,
-                placeholder = { Text("Поиск по названию или package") }
+                placeholder = { Text(stringResource(R.string.app_list_search_placeholder)) }
             )
             Spacer(Modifier.height(8.dp))
             LazyColumn(
@@ -131,9 +146,9 @@ fun AddAppSheet(
                     item {
                         Text(
                             if (normalizedQuery.isBlank())
-                                "Нет приложений, подходящих для добавления."
+                                stringResource(R.string.add_app_sheet_empty_for_add)
                             else
-                                "Ничего не найдено по запросу \"$normalizedQuery\".",
+                                stringResource(R.string.app_list_not_found, normalizedQuery),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp)
@@ -178,15 +193,21 @@ fun AddAppSheet(
                         }
                         if (app.group != null) {
                             val currentLabel = when (app.group) {
-                                AppGroup.LOCAL -> "Без VPN"
-                                AppGroup.LOCAL_AUTO_UNFREEZE -> "Увед."
-                                AppGroup.VPN_ONLY -> "Только VPN"
-                                AppGroup.LAUNCH_VPN -> "С VPN"
+                                AppGroup.LOCAL -> stringResource(R.string.group_label_no_vpn)
+                                AppGroup.LOCAL_AUTO_UNFREEZE -> stringResource(R.string.group_label_notify_short)
+                                AppGroup.VPN_ONLY -> stringResource(R.string.app_list_legend_label_vpn_only)
+                                AppGroup.LAUNCH_VPN -> stringResource(R.string.group_label_with_vpn)
+                            }
+                            val currentColor = when (app.group) {
+                                AppGroup.LOCAL -> MaterialTheme.colorScheme.error
+                                AppGroup.LOCAL_AUTO_UNFREEZE -> MaterialTheme.colorScheme.secondary
+                                AppGroup.VPN_ONLY -> MaterialTheme.colorScheme.tertiary
+                                AppGroup.LAUNCH_VPN -> MaterialTheme.colorScheme.primary
                             }
                             Text(
                                 currentLabel,
                                 style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                color = currentColor
                             )
                             Spacer(Modifier.width(8.dp))
                         }
@@ -213,7 +234,7 @@ fun AddAppSheet(
                     enabled = selectedPackages.isNotEmpty() && !isApplying,
                     modifier = Modifier.weight(1f)
                 ) {
-                    Text("Сбросить")
+                    Text(stringResource(R.string.common_reset))
                 }
                 Button(
                     onClick = {
@@ -227,7 +248,7 @@ fun AddAppSheet(
                     enabled = selectedPackages.isNotEmpty() && !isApplying,
                     modifier = Modifier.weight(1f)
                 ) {
-                    Text("Готово")
+                    Text(stringResource(R.string.common_done))
                 }
             }
             Spacer(Modifier.height(16.dp))
@@ -246,7 +267,10 @@ fun AddAppSheet(
                     )
                     Spacer(Modifier.height(8.dp))
                     offenders.forEach { pkg ->
-                        Text("• $pkg", style = MaterialTheme.typography.bodySmall)
+                        Text(
+                            stringResource(R.string.add_app_sheet_bullet_package, pkg),
+                            style = MaterialTheme.typography.bodySmall
+                        )
                     }
                 }
             },

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/AppListScreen.kt
@@ -1,6 +1,7 @@
 package sgnv.anubis.app.ui.screens
 
 import android.content.Context
+import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -22,6 +23,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -57,10 +59,12 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import sgnv.anubis.app.R
 import sgnv.anubis.app.data.DefaultRestrictedApps
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.model.InstalledAppInfo
@@ -68,11 +72,12 @@ import sgnv.anubis.app.ui.MainViewModel
 import sgnv.anubis.app.ui.util.renderToImageBitmap
 
 private val grayscaleFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) })
+private const val PREF_APP_LIST_LEGEND_EXPANDED = "app_list_legend_expanded"
 
-private enum class SortBy(val label: String) {
-    GROUP("По группе"),
-    NAME("По названию"),
-    PACKAGE("По package")
+private enum class SortBy(@StringRes val labelRes: Int) {
+    GROUP(R.string.app_list_sort_group),
+    NAME(R.string.app_list_sort_name),
+    PACKAGE(R.string.app_list_sort_package)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -90,6 +95,9 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var sortBy by rememberSaveable { mutableStateOf(SortBy.PACKAGE) }
     var sortMenuOpen by remember { mutableStateOf(false) }
+    var legendExpanded by remember {
+        mutableStateOf(prefs.getBoolean(PREF_APP_LIST_LEGEND_EXPANDED, true))
+    }
 
     var showAutoWarning by remember { mutableStateOf(false) }
     val dismissAutoWarning: () -> Unit = { showAutoWarning = false }
@@ -136,20 +144,20 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
                 singleLine = true,
-                placeholder = { Text("Название или package") },
+                placeholder = { Text(stringResource(R.string.app_list_search_placeholder)) },
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                 leadingIcon = {
                     IconButton(onClick = {
                         searchActive = false
                         searchQuery = ""
                     }) {
-                        Icon(Icons.Default.Close, contentDescription = "Закрыть поиск")
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.app_list_cd_close_search))
                     }
                 },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
                         IconButton(onClick = { searchQuery = "" }) {
-                            Icon(Icons.Default.Close, contentDescription = "Очистить")
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.common_clear))
                         }
                     }
                 }
@@ -170,20 +178,26 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                     },
                     contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
                 ) {
-                    Text("Авто-выбор", style = MaterialTheme.typography.labelMedium)
+                    Text(stringResource(R.string.app_list_auto_select), style = MaterialTheme.typography.labelMedium)
                 }
                 Text(
-                    "Без VPN: $noVpnCount | Увед.: $autoUnfreezeCount | Только VPN: $vpnOnlyCount | С VPN: $launchCount",
+                    stringResource(
+                        R.string.app_list_group_counts,
+                        noVpnCount,
+                        autoUnfreezeCount,
+                        vpnOnlyCount,
+                        launchCount
+                    ),
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.Medium,
                     modifier = Modifier.weight(1f).padding(start = 8.dp)
                 )
                 IconButton(onClick = { searchActive = true }) {
-                    Icon(Icons.Default.Search, contentDescription = "Поиск")
+                    Icon(Icons.Default.Search, contentDescription = stringResource(R.string.common_search))
                 }
                 Box {
                     TextButton(onClick = { sortMenuOpen = true }) {
-                        Text(sortBy.label, style = MaterialTheme.typography.labelMedium)
+                        Text(stringResource(sortBy.labelRes), style = MaterialTheme.typography.labelMedium)
                         Icon(Icons.Default.ArrowDropDown, contentDescription = null)
                     }
                     DropdownMenu(
@@ -192,7 +206,7 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                     ) {
                         SortBy.entries.forEach { option ->
                             DropdownMenuItem(
-                                text = { Text(option.label) },
+                                text = { Text(stringResource(option.labelRes)) },
                                 onClick = {
                                     sortBy = option
                                     sortMenuOpen = false
@@ -207,44 +221,83 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
         Spacer(Modifier.height(8.dp))
 
         // Legend
-        Column(
-            modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    legendExpanded = !legendExpanded
+                    prefs.edit { putBoolean(PREF_APP_LIST_LEGEND_EXPANDED, legendExpanded) }
+                },
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            LegendRow(
-                color = MaterialTheme.colorScheme.error,
-                label = "Без VPN",
-                description = "При включении VPN — заморожено. Запуск только без VPN."
+            Text(
+                stringResource(R.string.app_list_group_statuses_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.weight(1f)
             )
-            LegendRow(
-                color = MaterialTheme.colorScheme.secondary,
-                label = "Увед.",
-                description = "При VPN заморожено, без VPN — автоматически разморожено (для уведомлений)."
-            )
-            LegendRow(
-                color = MaterialTheme.colorScheme.tertiary,
-                label = "Только VPN",
-                description = "Без VPN заморожено. Запуск только через VPN."
-            )
-            LegendRow(
-                color = MaterialTheme.colorScheme.primary,
-                label = "С VPN",
-                description = "Не замораживается. При запуске автоматически включается VPN."
+            Icon(
+                imageVector = if (legendExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.ArrowDropDown,
+                contentDescription = null
             )
         }
 
+        if (legendExpanded) {
+            Spacer(Modifier.height(6.dp))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                LegendRow(
+                    color = MaterialTheme.colorScheme.error,
+                    label = stringResource(R.string.group_label_no_vpn),
+                    description = stringResource(R.string.app_list_legend_desc_local)
+                )
+                LegendRow(
+                    color = MaterialTheme.colorScheme.secondary,
+                    label = stringResource(R.string.group_label_notify_short),
+                    description = stringResource(R.string.app_list_legend_desc_local_auto)
+                )
+                LegendRow(
+                    color = MaterialTheme.colorScheme.tertiary,
+                    label = stringResource(R.string.app_list_legend_label_vpn_only),
+                    description = stringResource(R.string.app_list_legend_desc_vpn_only)
+                )
+                LegendRow(
+                    color = MaterialTheme.colorScheme.primary,
+                    label = stringResource(R.string.group_label_with_vpn),
+                    description = stringResource(R.string.app_list_legend_desc_launch_vpn)
+                )
+            }
+        }
         Spacer(Modifier.height(8.dp))
 
         TabRow(selectedTabIndex = selectedTab) {
             Tab(
                 selected = selectedTab == 0,
                 onClick = { selectedTab = 0 },
-                text = { Text("Пользовательские (${userApps.size})") }
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(stringResource(R.string.app_list_tab_user_label))
+                        Text(
+                            stringResource(R.string.app_list_tab_count, userApps.size),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
             )
             Tab(
                 selected = selectedTab == 1,
                 onClick = { selectedTab = 1 },
-                text = { Text("Системные (${systemApps.size})") }
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(stringResource(R.string.app_list_tab_system_label))
+                        Text(
+                            stringResource(R.string.app_list_tab_count, systemApps.size),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
             )
         }
 
@@ -277,7 +330,11 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                 if (sortedList.isEmpty()) {
                     item {
                         Text(
-                            if (normalizedQuery.isBlank()) "Список пуст. Потяните вниз, чтобы обновить." else "Ничего не найдено по запросу \"$normalizedQuery\".",
+                            if (normalizedQuery.isBlank()) {
+                                stringResource(R.string.app_list_empty)
+                            } else {
+                                stringResource(R.string.app_list_not_found, normalizedQuery)
+                            },
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier
@@ -322,23 +379,19 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     pendingFirstAdd?.let { pkg ->
         AlertDialog(
             onDismissRequest = dismissFirstAddDialog,
-            title = { Text("Добавить в группу?") },
+            title = { Text(stringResource(R.string.app_list_first_add_title)) },
             text = {
-                Text(
-                    "Приложение будет заморожено — после этого его ярлык исчезнет с рабочего стола. " +
-                    "Восстановить можно в любой момент через долгое нажатие на Главной → «Разморозить» → «Убрать из группы». " +
-                    "Для массовой отмены — раздел «Восстановление» в настройках."
-                )
+                Text(stringResource(R.string.app_list_first_add_text))
             },
             confirmButton = {
                 TextButton(onClick = {
                     prefs.edit { putBoolean("seen_first_add_warning", true) }
                     viewModel.cycleAppGroup(pkg)
                     dismissFirstAddDialog()
-                }) { Text("Добавить") }
+                }) { Text(stringResource(R.string.common_add)) }
             },
             dismissButton = {
-                TextButton(onClick = dismissFirstAddDialog) { Text("Отмена") }
+                TextButton(onClick = dismissFirstAddDialog) { Text(stringResource(R.string.common_cancel)) }
             }
         )
     }
@@ -346,25 +399,19 @@ fun AppListScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
     if (showAutoWarning) {
         AlertDialog(
             onDismissRequest = dismissAutoWarning,
-            title = { Text("Перед заморозкой") },
+            title = { Text(stringResource(R.string.app_list_auto_warning_title)) },
             text = {
-                Text(
-                    "Anubis заморозит известные российские приложения через системный pm disable. " +
-                    "Большинство лаунчеров уберут их иконки с рабочего стола — это не удаление, " +
-                    "приложения и данные сохранятся. Но после разморозки ярлыки не вернутся на прежние позиции — " +
-                    "придётся расставить руками.\n\n" +
-                    "Если что-то пойдёт не так — в настройках есть раздел «Восстановление» с массовой разморозкой."
-                )
+                Text(stringResource(R.string.app_list_auto_warning_text))
             },
             confirmButton = {
                 TextButton(onClick = {
                     prefs.edit { putBoolean("seen_auto_warning", true)}
                     dismissAutoWarning()
                     viewModel.autoSelectRestricted()
-                }) { Text("Заморозить") }
+                }) { Text(stringResource(R.string.common_freeze)) }
             },
             dismissButton = {
-                TextButton(onClick = dismissAutoWarning) { Text("Отмена") }
+                TextButton(onClick = dismissAutoWarning) { Text(stringResource(R.string.common_cancel)) }
             }
         )
     }
@@ -475,11 +522,11 @@ private fun AppRow(
             // Group badge
             Text(
                 when (app.group) {
-                    AppGroup.LOCAL -> "Без VPN"
-                    AppGroup.LOCAL_AUTO_UNFREEZE -> "Увед."
-                    AppGroup.VPN_ONLY -> "VPN"
-                    AppGroup.LAUNCH_VPN -> "С VPN"
-                    null -> "—"
+                    AppGroup.LOCAL -> stringResource(R.string.group_label_no_vpn)
+                    AppGroup.LOCAL_AUTO_UNFREEZE -> stringResource(R.string.group_label_notify_short)
+                    AppGroup.VPN_ONLY -> stringResource(R.string.app_list_group_badge_vpn_only)
+                    AppGroup.LAUNCH_VPN -> stringResource(R.string.group_label_with_vpn)
+                    null -> stringResource(R.string.app_list_group_badge_none)
                 },
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.Bold,

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/HomeScreen.kt
@@ -255,7 +255,6 @@ fun HomeScreen(
         }
 
         // App groups
-        if (localAutoUnfreezeApps.isNotEmpty()) {
             Spacer(Modifier.height(16.dp))
             AppGroupSection(
                 title = "Без VPN + уведомления",
@@ -268,9 +267,7 @@ fun HomeScreen(
                 onLongClick = { pkg -> menuApp = pkg },
                 onAdd = { addingToGroup = AppGroup.LOCAL_AUTO_UNFREEZE }
             )
-        }
 
-        if (localApps.isNotEmpty()) {
             Spacer(Modifier.height(16.dp))
             AppGroupSection(
                 title = "Без VPN",
@@ -283,9 +280,7 @@ fun HomeScreen(
                 onLongClick = { pkg -> menuApp = pkg },
                 onAdd = { addingToGroup = AppGroup.LOCAL }
             )
-        }
 
-        if (launchVpnApps.isNotEmpty()) {
             Spacer(Modifier.height(16.dp))
             AppGroupSection(
                 title = "Запуск с VPN",
@@ -298,9 +293,7 @@ fun HomeScreen(
                 onLongClick = { pkg -> menuApp = pkg },
                 onAdd = { addingToGroup = AppGroup.LAUNCH_VPN }
             )
-        }
 
-        if (vpnOnlyApps.isNotEmpty()) {
             Spacer(Modifier.height(16.dp))
             AppGroupSection(
                 title = "Только VPN",
@@ -313,41 +306,6 @@ fun HomeScreen(
                 onLongClick = { pkg -> menuApp = pkg },
                 onAdd = { addingToGroup = AppGroup.VPN_ONLY }
             )
-        }
-
-        if (localApps.isEmpty() && localAutoUnfreezeApps.isEmpty() && vpnOnlyApps.isEmpty() && launchVpnApps.isEmpty()) {
-            Spacer(Modifier.height(24.dp))
-            Text(
-                "Нет приложений в группах. Добавьте хотя бы в одну:",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(Modifier.height(12.dp))
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                EmptyGroupAddButton(
-                    label = "Без VPN + уведомления",
-                    tint = MaterialTheme.colorScheme.secondary,
-                    onClick = { addingToGroup = AppGroup.LOCAL_AUTO_UNFREEZE }
-                )
-                EmptyGroupAddButton(
-                    label = "Без VPN",
-                    tint = MaterialTheme.colorScheme.error,
-                    onClick = { addingToGroup = AppGroup.LOCAL }
-                )
-                EmptyGroupAddButton(
-                    label = "Запуск с VPN",
-                    tint = MaterialTheme.colorScheme.primary,
-                    onClick = { addingToGroup = AppGroup.LAUNCH_VPN }
-                )
-                EmptyGroupAddButton(
-                    label = "Только VPN",
-                    tint = MaterialTheme.colorScheme.tertiary,
-                    onClick = { addingToGroup = AppGroup.VPN_ONLY }
-                )
-            }
-        }
 
         // Network
         Spacer(Modifier.height(16.dp))
@@ -714,27 +672,3 @@ private fun InfoRow(label: String, value: String) {
     }
 }
 
-@Composable
-private fun EmptyGroupAddButton(
-    label: String,
-    tint: Color,
-    onClick: () -> Unit,
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(Icons.Default.Add, contentDescription = null, tint = tint)
-            Spacer(Modifier.width(12.dp))
-            Text(
-                "Добавить в «$label»",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = tint
-            )
-        }
-    }
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,14 @@
     <string name="app_name">Anubis</string>
     <string name="tile_label">Anubis</string>
 
+    <string name="common_add">Добавить</string>
+    <string name="common_cancel">Отмена</string>
+    <string name="common_clear">Очистить</string>
+    <string name="common_done">Готово</string>
+    <string name="common_freeze">Заморозить</string>
+    <string name="common_reset">Сбросить</string>
+    <string name="common_search">Поиск</string>
+
     <string name="startup_status_scanning_progress">Сканирование приложений: %1$d / %2$d</string>
     <string name="startup_status_preparing_launch">Подготовка к запуску…</string>
     <string name="startup_version_format">Версия %1$s</string>
@@ -17,16 +25,50 @@
     <string name="add_app_sheet_no_safe_apps">Нет безопасных приложений для добавления</string>
     <string name="add_app_sheet_add_safe">Добавить только безопасные</string>
     <string name="add_app_sheet_add_anyway">Добавить все</string>
+    <string name="add_app_sheet_empty_for_add">Нет приложений, подходящих для добавления.</string>
+    <string name="add_app_sheet_group_local_auto_full">Без VPN + уведомления</string>
+    <string name="add_app_sheet_group_quoted">«%1$s»</string>
+    <string name="add_app_sheet_add_to_prefix">Добавить в</string>
+    <string name="add_app_sheet_bullet_package">• %1$s</string>
 
-    <string name="common_cancel">Отмена</string>
+    <string name="app_list_auto_select">Авто-выбор</string>
+    <string name="app_list_auto_warning_text">Anubis заморозит известные российские приложения через системный pm disable. Большинство лаунчеров уберут их иконки с рабочего стола — это не удаление, приложения и данные сохранятся. Но после разморозки ярлыки не вернутся на прежние позиции — придётся расставить руками.\n\nЕсли что-то пойдёт не так — в настройках есть раздел «Восстановление» с массовой разморозкой.</string>
+    <string name="app_list_auto_warning_title">Перед заморозкой</string>
+    <string name="app_list_cd_close_search">Закрыть поиск</string>
+    <string name="app_list_empty">Список пуст. Потяните вниз, чтобы обновить.</string>
+    <string name="app_list_first_add_text">Приложение будет заморожено — после этого его ярлык исчезнет с рабочего стола. Восстановить можно в любой момент через долгое нажатие на Главной → «Разморозить» → «Убрать из группы». Для массовой отмены — раздел «Восстановление» в настройках.</string>
+    <string name="app_list_first_add_title">Добавить в группу?</string>
+    <string name="app_list_group_badge_none">—</string>
+    <string name="app_list_group_badge_vpn_only">VPN</string>
+    <string name="app_list_group_counts">Без VPN: %1$d | Увед.: %2$d | Только VPN: %3$d | С VPN: %4$d</string>
+    <string name="app_list_group_statuses_title">Статусы групп</string>
+    <string name="app_list_legend_desc_launch_vpn">Не замораживается. При запуске автоматически включается VPN.</string>
+    <string name="app_list_legend_desc_local">При включении VPN — заморожено. Запуск только без VPN.</string>
+    <string name="app_list_legend_desc_local_auto">При VPN заморожено, без VPN — автоматически разморожено (для уведомлений).</string>
+    <string name="app_list_legend_desc_vpn_only">Без VPN заморожено. Запуск только через VPN.</string>
+    <string name="app_list_legend_label_vpn_only">Только VPN</string>
+    <string name="app_list_not_found">Ничего не найдено по запросу \"%1$s\".</string>
+    <string name="app_list_search_placeholder">Название или package</string>
+    <string name="app_list_sort_group">По группе</string>
+    <string name="app_list_sort_name">По названию</string>
+    <string name="app_list_sort_package">По package</string>
+    <string name="app_list_tab_count">(%1$d)</string>
+    <string name="app_list_tab_system_label">Системные</string>
+    <string name="app_list_tab_user_label">Пользовательские</string>
+
+    <string name="group_label_no_vpn">Без VPN</string>
+    <string name="group_label_notify_short">Увед.</string>
+    <string name="group_label_with_vpn">С VPN</string>
+
+    <string name="home_status_disabled">ЗАЩИТА ОТКЛЮЧЕНА</string>
+    <string name="home_status_disabling">ОТКЛЮЧЕНИЕ...</string>
     <string name="home_status_enabled">ЗАЩИТА АКТИВНА</string>
     <string name="home_status_enabling">ВКЛЮЧЕНИЕ...</string>
-    <string name="home_status_disabling">ОТКЛЮЧЕНИЕ...</string>
     <string name="home_status_unfreezing">РАЗМОРОЗКА...</string>
-    <string name="home_status_disabled">ЗАЩИТА ОТКЛЮЧЕНА</string>
 
-    <string name="settings_launcher_safe_mode_title">Безопасный режим лаунчера</string>
     <string name="settings_launcher_safe_mode_description">Уменьшает вероятность дубликатов ярлыков: массовая разморозка выполняется по одному приложению с короткой паузой.</string>
+    <string name="settings_launcher_safe_mode_title">Безопасный режим лаунчера</string>
+
     <string name="settings_journal_title">Журнал</string>
     <string name="settings_journal_description">Просмотр диагностических логов</string>
 


### PR DESCRIPTION
Решение для #125 #127 #128 

## Что сделано

Улучшены пользовательские сценарии работы с группами приложений
Реализована унификация цвета названия групп
UI-строки экрана вынесены в ресурсы. Для общих текстов использованы префиксы (`common_*`).

### Главный экран
- Все группы отображаются всегда
Первое приложение можно добавить сразу в нужную группу.
- Убран отдельный блок с кнопками добавления для полностью пустого состояния, чтобы не дублировать сценарий.

### AddAppSheet (добавление в группу)
- В заголовке листа название целевой группы подсвечивается цветом группы.

### Экран «Приложения»
- Панель подсказок статусов сделана сворачиваемой/разворачиваемой.
Состояние свёрнутости сохраняется в настройках (по умолчанию панель раскрыта).
- Вкладки «Пользовательские / Системные» переработаны: количество вынесено на вторую строку.

### Ресурсы
- Одинаковые по смыслу подписи групп сведены к единым ключам.

## Зачем

- Убрать блокирующий UX-дефект: невозможность добавить первое приложение в пустую группу с главного экрана.
- Сделать работу с группами более предсказуемой и единообразной на разных экранах.
- Снизить дальнейшие риски рассинхронизации текстов и цветов.

## Как проверить

1. **Главный экран**
   - Очистить группы и открыть главный экран.
   - Убедиться, что все группы видны даже пустыми.
   - Нажать `+` в пустой группе и добавить приложение.

2. **AddAppSheet**
   - Открыть добавление в разные группы с главного экрана.
   - Проверить, что название целевой группы в заголовке окрашено цветом группы.
   - Проверить единообразие цвета названий групп.

3. **Экран «Приложения»**
   - Развернуть/свернуть панель статусов по нажатию на заголовок.
   - Перезапустить экран/приложение и проверить, что состояние панели сохранено.
   - Проверить отображение табов: название на первой строке, количество на второй.

4. **Тексты**
   - Проверить, что все новые/изменённые подписи отображаются корректно и без регрессий.