### PR TITLE
Restore ownerUid compatibility fallback for legacy Android

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "sgnv.anubis.app"
-        minSdk = 29
+        minSdk = 28
         targetSdk = 34
         versionCode = 9
         versionName = "0.1.5-beta.2"

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -9,6 +9,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Build
 import android.os.IBinder
 import android.os.Process
 import androidx.core.app.NotificationCompat
@@ -108,7 +109,8 @@ class VpnMonitorService : Service() {
     }
 
     private fun isOwnVpnNetwork(cm: ConnectivityManager, network: Network): Boolean = try {
-        cm.getNetworkCapabilities(network)?.ownerUid == Process.myUid()
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                (cm.getNetworkCapabilities(network)?.ownerUid == Process.myUid())
     } catch (_: Exception) {
         false
     }


### PR DESCRIPTION
Реализация #106 

## Что сделано

- Для возможности поддержки `minSdk = 28` (Android 9) реализована совместимая проверка в `VpnMonitorService`:
  - обращение к `NetworkCapabilities.ownerUid` выполняется только на `SDK >= 30` (`Android 11+`).
- На Android ниже 11 эта проверка пропускается и используется fallback-логика.
- В конфигурации приложения установлен `minSdk = 28`.

## Зачем

- `ownerUid` доступен только на Android 11+, поэтому без проверки версии нельзя безопасно поддерживать устройства с более низким SDK.
- Добавленное решение устраняет эту проблему и позволяет корректно работать при `minSdk = 28`.

## Как проверить

1. Сборка:
   - убедиться, что проект собирается с `minSdk = 28`.

2. Запуск:
   - включить/выключить VPN,
   - убедиться, что приложение не падает и мониторинг работает.

## Риск

- Т.к. используется fallback-логика, точность определения “своей” VPN-сети может быть ниже, чем на Android 11+.