### PR TITLE
Add operation journal

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("androidx.startup:startup-runtime:1.2.0")
+    implementation("androidx.profileinstaller:profileinstaller:1.4.1")
 
     // Room
     implementation("androidx.room:room-runtime:2.6.1")

--- a/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
+++ b/app/src/main/java/sgnv/anubis/app/AnubisApp.kt
@@ -13,6 +13,7 @@ import sgnv.anubis.app.data.db.AppDatabase
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.service.StealthOrchestrator
 import sgnv.anubis.app.shizuku.ShizukuManager
+import sgnv.anubis.app.util.AppLogger
 import sgnv.anubis.app.vpn.VpnClientManager
 
 class AnubisApp : Application() {
@@ -53,8 +54,14 @@ class AnubisApp : Application() {
      */
     val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    @Volatile
+    private var previousUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
+
     override fun onCreate() {
         super.onCreate()
+        AppLogger.init(this)
+        installCrashLoggingHandler()
+        AppLogger.i(TAG, APP_START_LOG_MESSAGE)
 
         // Required on Android 9+ to reflect into @hide IPackageManager / IActivityManager
         // methods used by the binder-based freeze path in ShizukuManager.
@@ -90,7 +97,23 @@ class AnubisApp : Application() {
         getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
     }
 
+    private fun installCrashLoggingHandler() {
+        if (previousUncaughtExceptionHandler != null) return
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        previousUncaughtExceptionHandler = previous
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            AppLogger.e(
+                TAG,
+                "FATAL: Uncaught exception on thread=${thread.name}",
+                throwable
+            )
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
     companion object {
         const val CHANNEL_ID = "anubis_monitor"
+        private const val TAG = "AnubisApp"
+        private const val APP_START_LOG_MESSAGE = "Start"
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/service/BootReceiver.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/BootReceiver.kt
@@ -7,6 +7,7 @@ import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
+import sgnv.anubis.app.util.AppLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -42,7 +43,10 @@ class BootReceiver : BroadcastReceiver() {
                 val packages = repo.getPackagesByGroup(group)
                 for (pkg in packages) {
                     if (shizukuManager.isAppInstalled(pkg)) {
-                        shizukuManager.freezeApp(pkg)
+                        val result = shizukuManager.freezeApp(pkg)
+                        if (result.isFailure) {
+                            AppLogger.e(TAG, "boot.freezeApp failed for package=$pkg", result.exceptionOrNull())
+                        }
                     }
                 }
             }
@@ -52,9 +56,16 @@ class BootReceiver : BroadcastReceiver() {
             val autoUnfreezePackages = repo.getPackagesByGroup(AppGroup.LOCAL_AUTO_UNFREEZE)
             for (pkg in autoUnfreezePackages) {
                 if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
-                    shizukuManager.unfreezeApp(pkg)
+                    val result = shizukuManager.unfreezeApp(pkg)
+                    if (result.isFailure) {
+                        AppLogger.e(TAG, "boot.unfreezeApp failed for package=$pkg", result.exceptionOrNull())
+                    }
                 }
             }
         }
+    }
+
+    private companion object {
+        private const val TAG = "BootReceiver"
     }
 }

--- a/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthOrchestrator.kt
@@ -5,6 +5,7 @@ import sgnv.anubis.app.data.model.AppGroup
 import sgnv.anubis.app.data.repository.AppRepository
 import sgnv.anubis.app.settings.AppSettings
 import sgnv.anubis.app.shizuku.ShizukuManager
+import sgnv.anubis.app.util.AppLogger
 import sgnv.anubis.app.vpn.SelectedVpnClient
 import sgnv.anubis.app.vpn.VpnClientControls
 import sgnv.anubis.app.vpn.VpnClientManager
@@ -87,6 +88,7 @@ class StealthOrchestrator(
      * VPN_ONLY stays frozen — they are only unfrozen by explicit launch.
      */
     suspend fun enable(client: SelectedVpnClient) = withContext(Dispatchers.Default) {
+        AppLogger.i(TAG, "enable requested, client=${client.packageName}")
         // Detached-job pattern: enableImpl runs in a process-wide scope, we wait via
         // job.join() with a hard timeout. Why: the original `withTimeoutOrNull(120s) {
         // enableImpl(...) }` couldn't fire because enableImpl's chain hits a
@@ -122,7 +124,8 @@ class StealthOrchestrator(
         if (!checkShizuku()) return
 
         if (shouldFreezeClientInIdle(client.packageName)) {
-            shizukuManager.unfreezeApp(client.packageName)
+            val result = shizukuManager.unfreezeApp(client.packageName)
+            logShizukuFailure("enableImpl.unfreezeClient", client.packageName, result)
         }
 
         if (shizukuManager.isAppFrozen(client.packageName)) {
@@ -141,13 +144,19 @@ class StealthOrchestrator(
         _progressText.value = "Запускаю VPN..."
         val startError = vpnClientManager.startVPN(client)
         if (startError != null) {
+            AppLogger.e(TAG, "VPN start command failed: ${client.packageName}; error=$startError")
             fail(startError)
             return
         }
+        AppLogger.i(TAG, "VPN start command sent: ${client.packageName}")
 
         if (client.controlMode != VpnControlMode.MANUAL && !waitForVpnOn(10_000)) {
+            AppLogger.e(TAG, "VPN did not become active in time: ${client.packageName}")
             fail("VPN client ${client.displayName} did not come up in time.")
             return
+        }
+        if (client.controlMode != VpnControlMode.MANUAL) {
+            AppLogger.i(TAG, "VPN became active: ${client.packageName}")
         }
 
         bumpVersion()
@@ -172,6 +181,7 @@ class StealthOrchestrator(
      * LOCAL stays frozen — they are only unfrozen by explicit launch.
      */
     suspend fun disable(client: SelectedVpnClient, detectedPackage: String?) = withContext(Dispatchers.Default) {
+        AppLogger.i(TAG, "disable requested, client=${client.packageName}, detected=${detectedPackage.orEmpty()}")
         // See comment on enable() — same detached-job + join() with timeout pattern.
         _lastError.value = null
         _state.value = StealthState.DISABLING
@@ -255,7 +265,8 @@ class StealthOrchestrator(
         }
 
         if (shizukuManager.isAppFrozen(packageName)) {
-            shizukuManager.unfreezeApp(packageName)
+            val result = shizukuManager.unfreezeApp(packageName)
+            logShizukuFailure("launchWithVpn.unfreezeApp", packageName, result)
             bumpVersion()
         }
 
@@ -281,7 +292,8 @@ class StealthOrchestrator(
         }
 
         if (shizukuManager.isAppFrozen(packageName)) {
-            shizukuManager.unfreezeApp(packageName)
+            val result = shizukuManager.unfreezeApp(packageName)
+            logShizukuFailure("launchLocal.unfreezeApp", packageName, result)
             bumpVersion()
         }
 
@@ -294,9 +306,11 @@ class StealthOrchestrator(
     suspend fun toggleAppFrozen(packageName: String) {
         if (!checkShizuku()) return
         if (shizukuManager.isAppFrozen(packageName)) {
-            shizukuManager.unfreezeApp(packageName)
+            val result = shizukuManager.unfreezeApp(packageName)
+            logShizukuFailure("toggleAppFrozen.unfreezeApp", packageName, result)
         } else {
-            shizukuManager.freezeApp(packageName)
+            val result = shizukuManager.freezeApp(packageName)
+            logShizukuFailure("toggleAppFrozen.freezeApp", packageName, result)
         }
         bumpVersion()
     }
@@ -308,21 +322,35 @@ class StealthOrchestrator(
     }
 
     private suspend fun stopVpn(client: SelectedVpnClient, detectedPackage: String?): Boolean {
+        AppLogger.i(TAG, "Stopping VPN requested: client=${client.packageName}, detected=${detectedPackage.orEmpty()}")
         // Step 1: API stop — only for SEPARATE mode (explicit stop command).
         // TOGGLE is unreliable for stop (can re-enable immediately), skip to dummy VPN.
         if (client.controlMode == VpnControlMode.SEPARATE) {
             vpnClientManager.stopVPN(client)
-            if (waitForVpnOff(3000)) return true
+            if (waitForVpnOff(VPN_OFF_WAIT_AFTER_API_STOP_MS)) {
+                AppLogger.i(TAG, "VPN stopped after API stop: ${client.packageName}")
+                return true
+            }
         }
 
         // Step 2: Dummy VPN — take over as VPN, system kills theirs
         StealthVpnService.disconnect(context)
-        if (waitForVpnOff(2000)) return true
+        if (waitForVpnOff(VPN_OFF_WAIT_AFTER_DUMMY_MS)) {
+            AppLogger.i(TAG, "VPN stopped after dummy takeover: ${client.packageName}")
+            return true
+        }
 
         // Step 3: Force-stop the detected VPN app
         val pkg = detectedPackage ?: client.packageName
         shizukuManager.forceStopApp(pkg)
-        return waitForVpnOff(2000)
+            .also { logShizukuFailure("stopVpn.forceStopApp", pkg, it) }
+        val stopped = waitForVpnOff(VPN_OFF_WAIT_AFTER_FORCE_STOP_MS)
+        if (stopped) {
+            AppLogger.i(TAG, "VPN stopped after force-stop: $pkg")
+        } else {
+            AppLogger.e(TAG, "VPN is still active after stop sequence: $pkg")
+        }
+        return stopped
     }
 
     private suspend fun checkShizuku(): Boolean {
@@ -341,8 +369,11 @@ class StealthOrchestrator(
                 async {
                     sem.withPermit {
                         if (shizukuManager.isAppInstalled(pkg) && !shizukuManager.isAppFrozen(pkg)) {
-                            shizukuManager.freezeApp(pkg)
-                            counter.incrementAndGet()
+                            val result = shizukuManager.freezeApp(pkg)
+                            logShizukuFailure("freezeGroup.freezeApp", pkg, result)
+                            if (result.isSuccess) {
+                                counter.incrementAndGet()
+                            }
                         }
                     }
                 }
@@ -357,8 +388,11 @@ class StealthOrchestrator(
             var transitioned = 0
             packages.forEachIndexed { index, pkg ->
                 if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
-                    shizukuManager.unfreezeApp(pkg)
-                    transitioned++
+                    val result = shizukuManager.unfreezeApp(pkg)
+                    logShizukuFailure("unfreezeGroup.unfreezeApp", pkg, result)
+                    if (result.isSuccess) {
+                        transitioned++
+                    }
                 }
                 // On MIUI/HyperOS and some OEM launchers, bursts of package-enabled events
                 // are handled as repeated "new app" inserts and produce duplicate icons.
@@ -375,8 +409,11 @@ class StealthOrchestrator(
                 async {
                     sem.withPermit {
                         if (shizukuManager.isAppInstalled(pkg) && shizukuManager.isAppFrozen(pkg)) {
-                            shizukuManager.unfreezeApp(pkg)
-                            counter.incrementAndGet()
+                            val result = shizukuManager.unfreezeApp(pkg)
+                            logShizukuFailure("unfreezeGroup.unfreezeApp", pkg, result)
+                            if (result.isSuccess) {
+                                counter.incrementAndGet()
+                            }
                         }
                     }
                 }
@@ -395,6 +432,7 @@ class StealthOrchestrator(
             frozen > 0 -> "Заморожено $frozen за $formattedSecs с"
             else -> "Разморожено $unfrozen за $formattedSecs с"
         }
+        AppLogger.i(TAG, msg)
         _benchmark.tryEmit(msg)
     }
 
@@ -464,13 +502,21 @@ class StealthOrchestrator(
         val client = AppSettings.loadSelectedVpnClient(context)
         if (!shouldFreezeClientInIdle(client.packageName)) return
         if (!shizukuManager.awaitUserService(500)) return
-        shizukuManager.freezeApp(client.packageName)
+        val result = shizukuManager.freezeApp(client.packageName)
+        logShizukuFailure("freezeSelectedVpnClientIfNeeded.freezeApp", client.packageName, result)
+    }
+
+    private fun logShizukuFailure(op: String, packageName: String, result: Result<Unit>) {
+        if (result.isFailure) {
+            AppLogger.e(TAG, "$op failed for package=$packageName", result.exceptionOrNull())
+        }
     }
 
     private fun shouldFreezeClientInIdle(packageName: String): Boolean =
         packageName.isNotBlank() && VpnClientControls.getControlForPackage(packageName).freezeInIdle
 
     private companion object {
+        private const val TAG = "StealthOrchestrator"
         // Cap on concurrent Shizuku IPC calls during group freeze/unfreeze.
         // On Honor MagicOS parallel disable-user emits a flood of PACKAGE_REMOVED
         // broadcasts that overwhelms the stock launcher's grid repaint — 4 was
@@ -487,6 +533,10 @@ class StealthOrchestrator(
         // force-stop. If we hit this ceiling something is genuinely broken (Shizuku
         // wedged, VPN client unresponsive) — no point waiting longer.
         const val TOTAL_OP_TIMEOUT_MS = 45_000L
+
+        private const val VPN_OFF_WAIT_AFTER_API_STOP_MS = 3_000L
+        private const val VPN_OFF_WAIT_AFTER_DUMMY_MS = 2_000L
+        private const val VPN_OFF_WAIT_AFTER_FORCE_STOP_MS = 2_000L
 
         // Launcher-safe profile: serialize mass-unfreeze to avoid duplicate launcher icons.
         const val LAUNCHER_SAFE_UNFREEZE_DELAY_MS = 180L

--- a/app/src/main/java/sgnv/anubis/app/service/StealthVpnService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/StealthVpnService.kt
@@ -6,6 +6,7 @@ import android.net.VpnService
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import sgnv.anubis.app.util.AppLogger
 
 /**
  * Dummy VPN service to force-disconnect any active VPN.
@@ -42,7 +43,7 @@ class StealthVpnService : VpnService() {
                 Log.w(TAG, "establish() returned null — no VPN consent")
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to establish dummy VPN", e)
+            AppLogger.e(TAG, "Failed to establish dummy VPN", e)
         }
         stopSelf()
     }

--- a/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
+++ b/app/src/main/java/sgnv/anubis/app/service/VpnMonitorService.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import sgnv.anubis.app.AnubisApp
 import sgnv.anubis.app.R
 import sgnv.anubis.app.ui.MainActivity
+import sgnv.anubis.app.util.AppLogger
 import java.util.Collections
 
 /**
@@ -104,12 +105,15 @@ class VpnMonitorService : Service() {
 
         try {
             cm.registerNetworkCallback(request, networkCallback!!)
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "registerNetworkCallback failed", e)
+        }
     }
 
     private fun isOwnVpnNetwork(cm: ConnectivityManager, network: Network): Boolean = try {
         cm.getNetworkCapabilities(network)?.ownerUid == Process.myUid()
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        AppLogger.e(TAG, "isOwnVpnNetwork failed", e)
         false
     }
 
@@ -119,7 +123,9 @@ class VpnMonitorService : Service() {
             try {
                 val cm = getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager
                 cm.unregisterNetworkCallback(it)
-            } catch (_: Exception) {}
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "unregisterNetworkCallback failed", e)
+            }
             networkCallback = null
         }
     }
@@ -147,6 +153,7 @@ class VpnMonitorService : Service() {
     }
 
     companion object {
+        private const val TAG = "VpnMonitorService"
         const val ACTION_START = "sgnv.anubis.app.START_MONITOR"
         const val ACTION_STOP = "sgnv.anubis.app.STOP_MONITOR"
         const val NOTIFICATION_ID = 1

--- a/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/shizuku/ShizukuManager.kt
@@ -7,6 +7,7 @@ import android.content.pm.PackageManager
 import android.os.IBinder
 import android.os.Process
 import sgnv.anubis.app.IUserService
+import sgnv.anubis.app.util.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -130,7 +131,8 @@ class ShizukuManager(private val packageManager: PackageManager) {
         if (!isAvailable() || !hasPermission()) return
         try {
             Shizuku.bindUserService(serviceArgs, serviceConnection)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "bindUserService failed", e)
         }
     }
 
@@ -151,7 +153,8 @@ class ShizukuManager(private val packageManager: PackageManager) {
     fun unbindUserService() {
         try {
             Shizuku.unbindUserService(serviceArgs, serviceConnection, true)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "unbindUserService failed", e)
         }
         userService = null
     }
@@ -230,6 +233,7 @@ class ShizukuManager(private val packageManager: PackageManager) {
                     val service = userService ?: return@withContext null
                     service.execCommandWithOutput(args.toList().toTypedArray())
                 } catch (e: Exception) {
+                    AppLogger.e(TAG, "runCommandWithOutput failed: ${args.joinToString(" ")}", e)
                     null
                 }
             }
@@ -291,6 +295,7 @@ class ShizukuManager(private val packageManager: PackageManager) {
     }
 
     companion object {
+        private const val TAG = "ShizukuManager"
         const val REQUEST_CODE = 1001
 
         /**

--- a/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import sgnv.anubis.app.ui.screens.AppListScreen
 import sgnv.anubis.app.ui.screens.HomeScreen
+import sgnv.anubis.app.ui.screens.LogScreen
 import sgnv.anubis.app.ui.screens.RecoveryScreen
 import sgnv.anubis.app.ui.screens.SettingsScreen
 import sgnv.anubis.app.ui.screens.StartupScreen
@@ -61,9 +62,21 @@ class MainActivity : ComponentActivity() {
                 val message by viewModel.message.collectAsState()
                 var selectedTab by rememberSaveable { mutableIntStateOf(0) }
                 var showRecovery by rememberSaveable { mutableStateOf(false) }
+                var showJournal by rememberSaveable { mutableStateOf(false) }
                 val dismissRecovery: () -> Unit = { showRecovery = false }
+                val dismissJournal: () -> Unit = { showJournal = false }
+                val selectTab: (Int) -> Unit = { tab ->
+                    selectedTab = tab
+                    dismissRecovery()
+                    dismissJournal()
+                }
 
-                BackHandler(enabled = showRecovery, onBack = dismissRecovery)
+                BackHandler(enabled = showRecovery || showJournal) {
+                    when {
+                        showJournal -> dismissJournal()
+                        showRecovery -> dismissRecovery()
+                    }
+                }
 
                 if (startupLoading) {
                     StartupScreen(
@@ -75,25 +88,25 @@ class MainActivity : ComponentActivity() {
                             NavigationBar {
                                 NavigationBarItem(
                                     selected = selectedTab == 0,
-                                    onClick = { selectedTab = 0; dismissRecovery() },
+                                    onClick = { selectTab(0) },
                                     icon = { Icon(Icons.Default.Home, contentDescription = null) },
                                     label = { Text("Главная") }
                                 )
                                 NavigationBarItem(
                                     selected = selectedTab == 1,
-                                    onClick = { selectedTab = 1; dismissRecovery() },
+                                    onClick = { selectTab(1) },
                                     icon = { Icon(Icons.Default.List, contentDescription = null) },
                                     label = { Text("Приложения") }
                                 )
                                 NavigationBarItem(
                                     selected = selectedTab == 2,
-                                    onClick = { selectedTab = 2; dismissRecovery() },
+                                    onClick = { selectTab(2) },
                                     icon = { Icon(Icons.Default.Lock, contentDescription = null) },
                                     label = { Text("VPN") }
                                 )
                                 NavigationBarItem(
                                     selected = selectedTab == 3,
-                                    onClick = { selectedTab = 3; dismissRecovery() },
+                                    onClick = { selectTab(3) },
                                     icon = { Icon(Icons.Default.Settings, contentDescription = null) },
                                     label = { Text("Настройки") }
                                 )
@@ -104,6 +117,11 @@ class MainActivity : ComponentActivity() {
                             RecoveryScreen(
                                 viewModel = viewModel,
                                 onBack = dismissRecovery,
+                                modifier = Modifier.padding(padding)
+                            )
+                        } else if (showJournal) {
+                            LogScreen(
+                                onBack = dismissJournal,
                                 modifier = Modifier.padding(padding)
                             )
                         } else when (selectedTab) {
@@ -120,6 +138,7 @@ class MainActivity : ComponentActivity() {
                             3 -> SettingsScreen(
                                 viewModel = viewModel,
                                 onOpenRecovery = { showRecovery = true },
+                                onOpenJournal = { showJournal = true },
                                 modifier = Modifier.padding(padding)
                             )
                         }

--- a/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/MainViewModel.kt
@@ -40,7 +40,10 @@ import org.json.JSONObject
 import java.net.URL
 import java.util.concurrent.atomic.AtomicBoolean
 import sgnv.anubis.app.R
+import sgnv.anubis.app.util.AppLogger
 import sgnv.anubis.app.ui.util.renderToBitmap
+
+private const val TAG = "MainViewModel"
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -358,8 +361,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             var unfrozenCount = 0
             for (pkg in allManaged) {
                 if (shizukuManager.isAppFrozen(pkg)) {
-                    shizukuManager.unfreezeApp(pkg)
-                    unfrozenCount++
+                    val result = shizukuManager.unfreezeApp(pkg)
+                    if (result.isFailure) {
+                        AppLogger.e(TAG, "unfreezeAllAndClear.unfreezeApp failed for package=$pkg", result.exceptionOrNull())
+                    } else {
+                        unfrozenCount++
+                    }
                 }
                 repository.removeApp(pkg)
             }
@@ -382,8 +389,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
             var unfrozenCount = 0
             for (pkg in disabled) {
-                shizukuManager.unfreezeApp(pkg)
-                unfrozenCount++
+                val result = shizukuManager.unfreezeApp(pkg)
+                if (result.isFailure) {
+                    AppLogger.e(TAG, "unfreezeAllUserDisabled.unfreezeApp failed for package=$pkg", result.exceptionOrNull())
+                } else {
+                    unfrozenCount++
+                }
             }
             // Also clear DB so orchestrator state stays consistent
             for (pkg in repository.getAllManagedPackages()) {

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/LogScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/LogScreen.kt
@@ -1,0 +1,143 @@
+package sgnv.anubis.app.ui.screens
+
+import android.graphics.Typeface
+import android.view.Gravity
+import android.view.View
+import android.widget.EditText
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import sgnv.anubis.app.R
+import sgnv.anubis.app.util.AppLogger
+
+private val CONTENT_PADDING = 16.dp
+private val BACK_ICON_SPACING = 4.dp
+private val HEADER_BOTTOM_SPACING = 12.dp
+private const val LOG_TEXT_SIZE_SP = 12f
+private const val NO_PADDING = 0
+private const val NEW_LINE = "\n"
+
+@Composable
+fun LogScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val lines by AppLogger.lines.collectAsState()
+    var showClearDialog by remember { mutableStateOf(false) }
+    val dismissClearDialog: () -> Unit = { showClearDialog = false }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(CONTENT_PADDING)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            TextButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                Spacer(Modifier.width(BACK_ICON_SPACING))
+                Text(stringResource(R.string.log_screen_back))
+            }
+            Text(
+                stringResource(R.string.log_screen_title),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            TextButton(onClick = { showClearDialog = true }) {
+                Text(stringResource(R.string.log_screen_clear))
+            }
+        }
+
+        Spacer(Modifier.height(HEADER_BOTTOM_SPACING))
+
+        if (lines.isEmpty()) {
+            Text(
+                text = stringResource(R.string.log_screen_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            val text = lines.joinToString(separator = NEW_LINE)
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = {
+                    EditText(context).apply {
+                        isSingleLine = false
+                        maxLines = Int.MAX_VALUE
+                        typeface = Typeface.MONOSPACE
+                        textSize = LOG_TEXT_SIZE_SP
+                        setTextIsSelectable(true)
+                        isLongClickable = true
+                        isFocusable = true
+                        isFocusableInTouchMode = true
+                        showSoftInputOnFocus = false
+                        setPadding(NO_PADDING, NO_PADDING, NO_PADDING, NO_PADDING)
+                        gravity = Gravity.TOP or Gravity.START
+                        textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                        background = null
+                        keyListener = null
+                    }
+                },
+                update = { editText ->
+                    if (editText.text.toString() != text) {
+                        editText.setText(text)
+                        editText.setSelection(editText.text.length)
+                    }
+                }
+            )
+        }
+    }
+
+    if (showClearDialog) {
+        AlertDialog(
+            onDismissRequest = dismissClearDialog,
+            title = { Text(stringResource(R.string.log_screen_clear_confirm_title)) },
+            text = { Text(stringResource(R.string.log_screen_clear_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        AppLogger.clear()
+                        dismissClearDialog()
+                    }
+                ) {
+                    Text(stringResource(R.string.log_screen_clear_confirm_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = dismissClearDialog) {
+                    Text(stringResource(R.string.common_cancel))
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/sgnv/anubis/app/ui/screens/SettingsScreen.kt
@@ -35,6 +35,7 @@ import sgnv.anubis.app.ui.MainViewModel
 fun SettingsScreen(
     viewModel: MainViewModel,
     onOpenRecovery: () -> Unit = {},
+    onOpenJournal: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val shizukuStatus by viewModel.shizukuStatus.collectAsState()
@@ -193,6 +194,35 @@ fun SettingsScreen(
         }
 
         Spacer(Modifier.height(24.dp))
+
+        // Journal entry
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onOpenJournal() }
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.settings_journal_title),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        stringResource(R.string.settings_journal_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Text("›", style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+
+        Spacer(Modifier.height(12.dp))
 
         // Recovery entry
         Card(

--- a/app/src/main/java/sgnv/anubis/app/util/AppLogger.kt
+++ b/app/src/main/java/sgnv/anubis/app/util/AppLogger.kt
@@ -1,0 +1,111 @@
+package sgnv.anubis.app.util
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object AppLogger {
+    private const val MAX_LINES = 2000
+    private const val FILE_NAME = "journal.log"
+    private const val TIME_PATTERN = "HH:mm:ss"
+    private const val LEVEL_ERROR = "E"
+    private const val LEVEL_INFO = "I"
+    private const val LINE_SEPARATOR = "\n"
+    private const val INDENT = "    "
+    private const val EMPTY = ""
+
+    private val lock = Any()
+    private val timeFormatter = SimpleDateFormat(TIME_PATTERN, Locale.getDefault())
+    private val _lines = MutableStateFlow<List<String>>(emptyList())
+    val lines: StateFlow<List<String>> = _lines
+
+    @Volatile
+    private var logFile: File? = null
+
+    fun init(context: Context) {
+        synchronized(lock) {
+            if (logFile != null) return
+            val file = File(context.applicationContext.filesDir, FILE_NAME)
+            logFile = file
+            val restored = runCatching { file.readLines(Charsets.UTF_8) }.getOrDefault(emptyList())
+            _lines.value = restored.takeLast(MAX_LINES)
+        }
+    }
+
+    fun e(tag: String, message: String, throwable: Throwable? = null) {
+        runCatching { Log.e(tag, message, throwable) }
+        val base = formatLine(level = LEVEL_ERROR, tag = tag, message = message)
+        val stackLines = throwable
+            ?.toSafeStackTraceString()
+            ?.lineSequence()
+            ?.map { "$INDENT$it" }
+            ?.toList()
+            .orEmpty()
+        appendLines(listOf(base) + stackLines)
+    }
+
+    fun i(tag: String, message: String) {
+        runCatching { Log.i(tag, message) }
+        appendLines(listOf(formatLine(level = LEVEL_INFO, tag = tag, message = message)))
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            _lines.value = emptyList()
+            runCatching { logFile?.writeText(EMPTY, Charsets.UTF_8) }
+        }
+    }
+
+    private fun formatLine(level: String, tag: String, message: String): String {
+        val time = timeFormatter.format(Date())
+        return "$time $level/$tag: $message"
+    }
+
+    private fun appendLines(newLines: List<String>) {
+        if (newLines.isEmpty()) return
+        synchronized(lock) {
+            val updated = ArrayList(_lines.value)
+            updated.addAll(newLines)
+            val extra = updated.size - MAX_LINES
+            if (extra > 0) {
+                updated.subList(0, extra).clear()
+            }
+            _lines.value = updated
+
+            val file = logFile
+            if (file != null) {
+                runCatching {
+                    file.appendText(
+                        newLines.joinToString(separator = LINE_SEPARATOR, postfix = LINE_SEPARATOR),
+                        Charsets.UTF_8
+                    )
+                }
+                if (extra > 0) {
+                    runCatching {
+                        file.writeText(
+                            updated.joinToString(separator = LINE_SEPARATOR, postfix = LINE_SEPARATOR),
+                            Charsets.UTF_8
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun Throwable.toSafeStackTraceString(): String {
+        return runCatching {
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            printStackTrace(pw)
+            pw.flush()
+            sw.toString()
+        }.getOrDefault("${this::class.java.name}: ${message.orEmpty()}")
+    }
+}

--- a/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
+++ b/app/src/main/java/sgnv/anubis/app/vpn/VpnClientManager.kt
@@ -8,6 +8,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.util.Log
 import sgnv.anubis.app.shizuku.ShizukuManager
+import sgnv.anubis.app.util.AppLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -165,6 +166,7 @@ class VpnClientManager(
                 // fallback steps. If we hide our dummy, waitForVpnOff exits early and
                 // launchLocal unfreezes with the external VPN still up (issue #63).
                 _vpnActive.value = true
+                AppLogger.i(TAG, "VPN network available: id=${network.hashCode()}")
                 CoroutineScope(Dispatchers.IO).launch { detectActiveVpnClient() }
             }
 
@@ -174,6 +176,7 @@ class VpnClientManager(
                 // this the check sees the dying network and _vpnActive stays true.
                 val stillActive = isVpnCurrentlyActive(cm, exclude = network)
                 _vpnActive.value = stillActive
+                AppLogger.i(TAG, "VPN network lost: id=${network.hashCode()}, stillActive=$stillActive")
                 if (!stillActive) {
                     _activeVpnClient.value = null
                     _activeVpnPackage.value = null
@@ -193,7 +196,8 @@ class VpnClientManager(
             try {
                 val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
                 cm.unregisterNetworkCallback(it)
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "unregisterNetworkCallback failed in stopMonitoringVpn", e)
             }
             networkCallback = null
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,14 @@
 
     <string name="settings_launcher_safe_mode_title">Безопасный режим лаунчера</string>
     <string name="settings_launcher_safe_mode_description">Уменьшает вероятность дубликатов ярлыков: массовая разморозка выполняется по одному приложению с короткой паузой.</string>
+    <string name="settings_journal_title">Журнал</string>
+    <string name="settings_journal_description">Просмотр диагностических логов</string>
+
+    <string name="log_screen_title">Журнал</string>
+    <string name="log_screen_back">Назад</string>
+    <string name="log_screen_clear">Очистить</string>
+    <string name="log_screen_empty">Нет записей</string>
+    <string name="log_screen_clear_confirm_title">Очистить журнал?</string>
+    <string name="log_screen_clear_confirm_message">Все записи журнала будут удалены.</string>
+    <string name="log_screen_clear_confirm_action">Очистить</string>
 </resources>


### PR DESCRIPTION
Решение #133 

## Что сделано

Добавлен встроенный журнал операций для диагностики работы приложения.

### Основное
- Реализован `AppLogger` с записью в `Logcat` и в файл (`journal.log`) с лимитом 2000 строк.
- В `Настройки` добавлена плашка **«Журнал»** с переходом на соответствующий экран
- Расширено логирование ключевых операций VPN/заморозки и ошибок в ранее «тихих» `catch`.
- Добавлен глобальный `UncaughtExceptionHandler`, чтобы фатальные необработанные исключения тоже попадали в журнал.

## Зачем

- Упростить диагностику кейсов «не замораживаются приложения» и «непонятно, что произошло».
- Иметь доступ к логам прямо в приложении, в том числе после перезапуска процесса.

## Проверка

1. Выполнить операции включения/отключения защиты и активации VPN.
2. Проверить, что записи появляются в журнале и сохраняются после перезапуска.
3. Нажать **Очистить** и увидеть удаление.